### PR TITLE
Add non compliant and compliant samples for PHP detectors

### DIFF
--- a/src/rule_based_detector_library/PHP/detectors/php-allow-url-fopen-or-include/php-allow-url-fopen-or-include_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-allow-url-fopen-or-include/php-allow-url-fopen-or-include_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-allow-url-fopen-or-include@v1.0 defects=0}
+// Compliant: `allow_url_fopen` is set to `Off`.
+    ini_set('allow_url_fopen', 'Off');
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-allow-url-fopen-or-include/php-allow-url-fopen-or-include_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-allow-url-fopen-or-include/php-allow-url-fopen-or-include_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-allow-url-fopen-or-include@v1.0 defects=1}
+// Noncompliant: `allow_url_fopen` is set to `On`.
+    ini_set('allow_url_fopen', 'On');
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-assert-use/php-assert-use_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-assert-use/php-assert-use_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-assert-use@v1.0 defects=0}
+// Compliant: `assert` input is not tainted.
+   assert('3 > 2');
+// {/fact}
+
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-assert-use/php-assert-use_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-assert-use/php-assert-use_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-assert-use@v1.0 defects=1}
+// NonCompliant: The `userInput` is not sanitized.
+    $unsanitizedInput = $_GET['userInput'];
+    assert($unsanitizedInput);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-avoid-exit-die/php-avoid-exit-die_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-avoid-exit-die/php-avoid-exit-die_compliant.php
@@ -1,0 +1,15 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-avoid-exit-die@v1.0 defects=0}
+// Compliant: Exception thrown in a compliant way.
+function compliant($inputValue)  { 
+    if ($inputValue == 42) {
+      throw new Exception('Value 42 is not expected.');
+    }
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-avoid-exit-die/php-avoid-exit-die_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-avoid-exit-die/php-avoid-exit-die_non-compliant.php
@@ -1,0 +1,15 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-avoid-exit-die@v1.0 defects=1}
+// Noncompliant: `exit()` is used to terminate the script.
+function nonCompliant($inputValue)  { 
+    if ($inputValue === 42) {
+        exit(23);
+    }
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-cookie-without-http-only-flag/php-cookie-without-http-only-flag_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-cookie-without-http-only-flag/php-cookie-without-http-only-flag_compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-cookie-without-http-only-flag@v1.0 defects=0}
+// Compliant: `http-only` flag set to `true`.
+$cookieLifetime = $lifetime;
+$cookiePath = $path;
+$cookieDomain = $domain;
+session_set_cookie_params($cookieLifetime, $cookiePath, $cookieDomain, true, true); 
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-cookie-without-http-only-flag/php-cookie-without-http-only-flag_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-cookie-without-http-only-flag/php-cookie-without-http-only-flag_non-compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-cookie-without-http-only-flag@v1.0 defects=1}
+// Noncompliant: `http-only` flag set to `false`.
+$cookieDuration = $lifetime;
+$cookieLocation = $path; 
+$cookieSite = $domain;
+session_set_cookie_params($cookieDuration, $cookieLocation, $cookieSite, true, false);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-curl-ssl-verifypeer-off/php-curl-ssl-verifypeer-off_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-curl-ssl-verifypeer-off/php-curl-ssl-verifypeer-off_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-curl-ssl-verifypeer-off@v1.0 defects=0}
+// Compliant: `CURLOPT_SSL_VERIFYPEER` is set to `true`.
+$curlHandle = $ch; 
+curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, true);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-curl-ssl-verifypeer-off/php-curl-ssl-verifypeer-off_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-curl-ssl-verifypeer-off/php-curl-ssl-verifypeer-off_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-curl-ssl-verifypeer-off@v1.0 defects=1}
+// Noncompliant: `CURLOPT_SSL_VERIFYPEER` is set to `false`.
+$curlSession = $ch;
+curl_setopt($curlSession, CURLOPT_SSL_VERIFYPEER, false);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-doctrine-orm-dangerous-query/php-doctrine-orm-dangerous-query_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-doctrine-orm-dangerous-query/php-doctrine-orm-dangerous-query_compliant.php
@@ -1,0 +1,20 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-doctrine-orm-dangerous-query@v1.0 defects=0}
+// Compliant: Uses parameterized query to prevent SQL injection.
+function executeCompliantQuery($userInput)
+{
+    $queryBuilder = $dbConnection->createQueryBuilder(); 
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->where('email = ?')
+        ->setParameter(0, $userInput)
+    ;
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-doctrine-orm-dangerous-query/php-doctrine-orm-dangerous-query_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-doctrine-orm-dangerous-query/php-doctrine-orm-dangerous-query_non-compliant.php
@@ -1,0 +1,19 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-doctrine-orm-dangerous-query@v1.0 defects=1}
+// Noncompliant: Direct concatenation of user input in query, vulnerable to SQL injection.
+function executeUnsafeQuery($unsafeInput) 
+{
+    $dbQueryBuilder = $dbConnection->createQueryBuilder();
+    $dbQueryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->where('email = ' . $unsafeInput)
+    ;
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-echoed-request/php-echoed-request_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-echoed-request/php-echoed-request_compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-echoed-request@v1.0 defects=0}
+function greetUser() { 
+    $userName = $_REQUEST['name'];
+    // Compliant: `htmlentities` provides a compliant way to display user input safely.
+    print("Hello: " . htmlentities($userName)); 
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-echoed-request/php-echoed-request_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-echoed-request/php-echoed-request_non-compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-echoed-request@v1.0 defects=1}
+function displayUnsafeGreeting() { 
+    $userInput = $_REQUEST['name'];
+    // Noncompliant: `$userInput` statement is non-compliant as it can leave the application vulnerable to cross-site scripting attacks.
+    echo "Hello: " . $userInput; 
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-editors-and-updates-security-sensitive/php-editors-and-updates-security-sensitive_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-editors-and-updates-security-sensitive/php-editors-and-updates-security-sensitive_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-editors-and-updates-security-sensitive@v1.0 defects=0}
+// Compliant: Enables automatic core updates for WordPress, enhancing security.
+define( 'WP_AUTO_UPDATE_CORE', true ); 
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-editors-and-updates-security-sensitive/php-editors-and-updates-security-sensitive_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-editors-and-updates-security-sensitive/php-editors-and-updates-security-sensitive_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-editors-and-updates-security-sensitive@v1.0 defects=1}
+// Noncompliant: Disables automatic core updates, potentially leaving WordPress vulnerable to security issues
+define( 'WP_AUTO_UPDATE_CORE', false ); 
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-extract-user-data/php-extract-user-data_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-extract-user-data/php-extract-user-data_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-extract-user-data@v1.0 defects=0}
+// Compliant: `EXTR_SKIP` is used to skip the extraction of the variable.
+$fileData = $_FILES["/some/bad/path"];
+extract($fileData, EXTR_SKIP, "prefixVar");
+// {/fact}     
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-extract-user-data/php-extract-user-data_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-extract-user-data/php-extract-user-data_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-extract-user-data@v1.0 defects=1}
+$unsafeFileData = $_FILES["/some/bad/path"];
+// Noncompliant: `EXTR_PREFIX_SAME` is used to extract variables with the same name, which can lead to security issues.
+extract($unsafeFileData, EXTR_PREFIX_SAME, "unsafePrefix");
+// {/fact} 
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-file-inclusion/php-file-inclusion_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-file-inclusion/php-file-inclusion_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-file-inclusion@v1.0 defects=0}
+// Compliant: Non-tainted input is passed to the function.
+include_once('config_constants.php');
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-file-inclusion/php-file-inclusion_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-file-inclusion/php-file-inclusion_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-file-inclusion@v1.0 defects=1}
+$unsafeUserInput = $_GET["tainted"];
+// Noncompliant: `$unsafeUserInput` is not sanitized, leading to a potential file inclusion vulnerability.
+include_once($unsafeUserInput); 
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-ftp-use/php-ftp-use_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-ftp-use/php-ftp-use_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-ftp-use@v1.0 defects=0}
+// Compliant: Secure file transfer using functions like `ssh2_auth_password`.
+ssh2_auth_password($sshConnection, $username, $password);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-ftp-use/php-ftp-use_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-ftp-use/php-ftp-use_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-ftp-use@v1.0 defects=1}
+// Noncompliant: Used insecure FTP functions that transmit credentials in plain text, such as `ftp_login`.
+$ftpLoginResult = ftp_login($ftpConnection, $ftpUsername, $ftpPassword);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-insecure-logging-config/php-insecure-logging-config_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-insecure-logging-config/php-insecure-logging-config_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-insecure-logging-config@v1.0 defects=0}
+// Compliant: Enables error logging, improving security by allowing detection and investigation of potential issues.
+ini_set('enable_error_logging', '1');
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-insecure-logging-config/php-insecure-logging-config_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-insecure-logging-config/php-insecure-logging-config_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-insecure-logging-config@v1.0 defects=1}
+// Noncompliant: Sets a low maximum length for error logs, potentially truncating important security-related information.
+ini_set('log_errors_max_length', '112'); 
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-insecure-socket-usage/php-insecure-socket-usage_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-insecure-socket-usage/php-insecure-socket-usage_compliant.php
@@ -1,0 +1,15 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-insecure-socket-usage@v1.0 defects=0}
+// Compliant: Enables peer verification for SSL connections, enhancing security by validating the authenticity of the remote server.
+$secureContext = stream_context_create([
+  'ssl' => [
+    'verify_peer' => true,
+  ],
+]);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-insecure-socket-usage/php-insecure-socket-usage_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-insecure-socket-usage/php-insecure-socket-usage_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-insecure-socket-usage@v1.0 defects=1}
+// Noncompliant: Creates a pair of connected, non-encrypted sockets, potentially exposing sensitive data to interception.
+$socketPair = stream_socket_pair($domain, $socketType, $socketProtocol);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-active-debug-code/php-laravel-active-debug-code_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-active-debug-code/php-laravel-active-debug-code_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-laravel-active-debug-code@v1.0 defects=0}
+// Compliant: Debug mode is disabled.
+    config(['app.debug' => false]);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-active-debug-code/php-laravel-active-debug-code_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-active-debug-code/php-laravel-active-debug-code_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-laravel-active-debug-code@v1.0 defects=1}
+// Noncompliant: Debug mode is enabled.
+    config(['app.debug' => 'true']); 
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-long-timeout/php-laravel-cookie-long-timeout_compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-long-timeout/php-laravel-cookie-long-timeout_compliant.session.php
@@ -1,0 +1,23 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-long-timeout@v1.0 defects=0}
+// Compliant: Sets a short session 'lifetime', reducing the risk of unauthorized access through prolonged sessions.
+function getIlluminateConfig(): ConfigRepository
+{
+    return new ConfigRepository([
+        'session' => [
+            'lifetime' => 20,
+            'files' => $this->paths->storage.'/sessions',
+            'cookie' => 'session'
+        ],
+        'view' => [
+            'paths' => [],
+        ],
+    ]);
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-long-timeout/php-laravel-cookie-long-timeout_non-compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-long-timeout/php-laravel-cookie-long-timeout_non-compliant.session.php
@@ -1,0 +1,23 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-long-timeout@v1.0 defects=1}
+// Noncompliant: Sets a long session 'lifetime', increasing the risk of unauthorized access through session hijacking.
+function getIlluminateConfig(): ConfigRepository
+{
+    return new ConfigRepository([
+        'session' => [
+            'lifetime' => 120,
+            'files' => $this->paths->storage.'/sessions',
+            'cookie' => 'session'
+        ],
+        'view' => [
+            'paths' => [],
+        ],
+    ]);
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-null-domain/php-laravel-cookie-null-domain_compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-null-domain/php-laravel-cookie-null-domain_compliant.session.php
@@ -1,0 +1,19 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-null-domain@v1.0 defects=0}
+// Compliant: Sets a secure cookie with null domain, limiting its scope and enhancing security.
+$cookie_name = "test_cookie";
+$cookie_value = "test_value";
+$cookie_expiration = time(); 
+$cookie_path = "/"; 
+setcookie($cookie_name, $cookie_value, [
+    'expires' => $cookie_expiration,
+    'domain' => null,
+    'secure' => true, 
+]);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-null-domain/php-laravel-cookie-null-domain_non-compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-null-domain/php-laravel-cookie-null-domain_non-compliant.session.php
@@ -1,0 +1,19 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-null-domain@v1.0 defects=1}
+// Noncompliant: Sets a cookie with a specific domain, potentially allowing access from subdomains and increasing security risks.
+$cookie_name = "test_cookie";
+$cookie_value = "test_value";
+$cookie_expiration = time();
+$cookie_path = "/";
+setcookie($cookie_name, $cookie_value, [
+    'expires' => $cookie_expiration,
+    'domain' => "baddomain.com",
+    'secure' => true, 
+]);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-same-site/php-laravel-cookie-same-site_compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-same-site/php-laravel-cookie-same-site_compliant.session.php
@@ -1,0 +1,30 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-same-site@v1.0 defects=0}
+// Compliant: Sets `same_site` attribute to `lax`, providing a good balance between security and functionality for cookies.
+return [
+
+    'driver' => env('SESSION_DRIVER', 'file'),
+    'lifetime' => env('SESSION_LIFETIME', 120),
+    'expire_on_close' => false,
+    'encrypt' => false,
+    'files' => storage_path('framework/sessions'),
+    'connection' => null,
+    'store' => null,
+    'cookie' => env(
+        'SESSION_COOKIE',
+        str_slug(env('APP_NAME', 'laravel'), '_').'_session'
+    ),
+    'path' => '/',
+    'domain' => env('SESSION_DOMAIN', null),
+    'secure' => env('SESSION_SECURE_COOKIE', false),
+    'http_only' => true,
+    'same_site' => 'lax',
+
+];
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-same-site/php-laravel-cookie-same-site_non-compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-same-site/php-laravel-cookie-same-site_non-compliant.session.php
@@ -1,0 +1,28 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-same-site@v1.0 defects=1}
+// Noncompliant: Missing `same_site` attribute for cookies, potentially exposing the application to cross-site request forgery (CSRF) attacks.
+return [
+
+    'driver' => env('SESSION_DRIVER', 'file'),
+    'lifetime' => env('SESSION_LIFETIME', 120),
+    'expire_on_close' => false,
+    'encrypt' => false,
+    'files' => storage_path('framework/sessions'),
+    'connection' => null,
+    'store' => null,
+    'cookie' => env(
+        'SESSION_COOKIE',
+        str_slug(env('APP_NAME', 'laravel'), '_').'_session'
+    ),
+    'path' => '/',
+    'domain' => env('SESSION_DOMAIN', null),
+    'secure' => env('SESSION_SECURE_COOKIE', false),
+
+];
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-secure-set/php-laravel-cookie-secure-set_compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-secure-set/php-laravel-cookie-secure-set_compliant.session.php
@@ -1,0 +1,28 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-secure-set@v1.0 defects=0}
+// Compliant: Sets `secure` flag to `true`, ensuring cookies are only transmitted over HTTPS, enhancing data protection.
+return [
+    'driver' => env('SESSION_DRIVER', 'file'),
+    'lifetime' => env('SESSION_LIFETIME', 120),
+    'expire_on_close' => false,
+    'encrypt' => false,
+    'files' => storage_path('framework/sessions'),
+    'connection' => null,
+    'store' => null,
+    'cookie' => env(
+        'SESSION_COOKIE',
+        str_slug(env('APP_NAME', 'laravel'), '_').'_session'
+    ),
+    'path' => '/',
+    'domain' => env('SESSION_DOMAIN', null),
+    'secure' => true,
+    'http_only' => true,
+    'same_site' => 'lax',
+];
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-secure-set/php-laravel-cookie-secure-set_non-compliant.session.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-cookie-secure-set/php-laravel-cookie-secure-set_non-compliant.session.php
@@ -1,0 +1,28 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-cookie-secure-set@v1.0 defects=1}
+// Noncompliant: `secure` flag set to `false`, allowing cookies to be transmitted over insecure HTTP connections, risking data exposure.
+return [
+    'driver' => env('SESSION_DRIVER', 'file'),
+    'lifetime' => env('SESSION_LIFETIME', 120),
+    'expire_on_close' => false,
+    'encrypt' => false,
+    'files' => storage_path('framework/sessions'),
+    'connection' => null,
+    'store' => null,
+    'cookie' => env(
+        'SESSION_COOKIE',
+        str_slug(env('APP_NAME', 'laravel'), '_').'_session'
+    ),
+    'path' => '/',
+    'domain' => env('SESSION_DOMAIN', null),
+    'secure' => false,
+    'http_only' => true,
+    'same_site' => 'lax',
+];
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-dangerous-model-construction/php-laravel-dangerous-model-construction_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-dangerous-model-construction/php-laravel-dangerous-model-construction_compliant.php
@@ -1,0 +1,18 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-dangerous-model-construction@v1.0 defects=0}
+// Compliant: Uses `$guarded` to explicitly specify attributes that should not be mass-assignable, enhancing security against mass assignment vulnerabilities.
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class FlightDetails extends Model
+{
+    protected $key = 'flight_id';
+    protected $guarded = ['name', 'email'];
+
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-laravel-dangerous-model-construction/php-laravel-dangerous-model-construction_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-laravel-dangerous-model-construction/php-laravel-dangerous-model-construction_non-compliant.php
@@ -1,0 +1,18 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-laravel-dangerous-model-construction@v1.0 defects=1}
+// Noncompliant: Uses an empty `$guarded` array, allowing mass assignment for all attributes and potentially exposing the model to security vulnerabilities.
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class FlightRecord extends Model
+{
+    protected $key = 'flight_id';
+    protected $guarded = []; 
+
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-ldap-bind-without-password/php-ldap-bind-without-password_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-ldap-bind-without-password/php-ldap-bind-without-password_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-ldap-bind-without-password@v1.0 defects=0}
+// Compliant: Username and password provided.
+$ldapConnection = ldap_connect("foo.com");
+ldap_bind($ldapConnection, "user@example.com", "securePassword123");
+//{fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-ldap-bind-without-password/php-ldap-bind-without-password_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-ldap-bind-without-password/php-ldap-bind-without-password_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-ldap-bind-without-password@v1.0 defects=1}
+// Noncompliant: Username and password is missing.
+$ldapConnection = ldap_connect("foo.com");
+ldap_bind($ldapConnection, NULL, NULL);
+// {fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-mb-ereg-replace-eval/php-mb-ereg-replace-eval_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-mb-ereg-replace-eval/php-mb-ereg-replace-eval_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-mb-ereg-replace-eval@v1.0 defects=0}
+// Compliant: Uses `mb_eregi(`) function without the 'e' modifier, avoiding potential code execution vulnerabilities.
+mb_eregi($searchPattern, $inputString, "safe-options");
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-mb-ereg-replace-eval/php-mb-ereg-replace-eval_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-mb-ereg-replace-eval/php-mb-ereg-replace-eval_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-mb-ereg-replace-eval@v1.0 defects=1}
+// Noncompliant: Uses unvalidated user input directly in `mb_ereg()`, potentially allowing injection of malicious patterns or exploits.
+$userInput = $_GET['pattern'];
+mb_ereg($searchPattern, $inputString, $userInput); 
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-mcrypt-use/php-mcrypt-use_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-mcrypt-use/php-mcrypt-use_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-mcrypt-use@v1.0 defects=0}
+// Compliant: `openssl_encrypt` function to perform encryption using the OpenSSL library.
+    openssl_encrypt($plainTextData, $encryptionMethod, $encryptionKey, $encryptionOptions = 0, $initializationVector, $authenticationTag);
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-mcrypt-use/php-mcrypt-use_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-mcrypt-use/php-mcrypt-use_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-mcrypt-use@v1.0 defects=1}
+// Noncompliant: `mcrypt_ecb` function to perform encryption using the ECB.
+    mcrypt_ecb(MCRYPT_BLOWFISH, $encryptionKey, base64_decode($inputData), MCRYPT_ENCRYPT);
+// {/fact}
+
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-md5-loose-equality/php-md5-loose-equality_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-md5-loose-equality/php-md5-loose-equality_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-md5-loose-equality@v1.0 defects=0}
+// Compliant: Used type-safe comparison `===`.
+$isMd5Match = md5("240610708") === "0";
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-md5-loose-equality/php-md5-loose-equality_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-md5-loose-equality/php-md5-loose-equality_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-md5-loose-equality@v1.0 defects=1}
+// Noncompliant: Used loose equality `==`.
+$isMd5Match = md5("240610708") == "0";
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-openssl-cbc-static-iv/php-openssl-cbc-static-iv_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-openssl-cbc-static-iv/php-openssl-cbc-static-iv_compliant.php
@@ -1,0 +1,18 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-openssl-cbc-static-iv@v1.0 defects=0}
+function encryptData($plaintext, $password) {
+    $encryptionMethod = "AES-256-CBC";
+    $encryptionKey = hash('sha256', $password, true);
+    $initializationVector = openssl_random_pseudo_bytes(16);
+    // Compliant: `$initializationVector` is used to initialize the cipher
+    $ciphertext = openssl_encrypt($plaintext, $encryptionMethod, $encryptionKey, OPENSSL_RAW_DATA, $initializationVector);
+    $hash = hash_hmac('sha256', $ciphertext . $initializationVector, $encryptionKey, true);
+    return $initializationVector . $hash . $ciphertext;
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-openssl-cbc-static-iv/php-openssl-cbc-static-iv_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-openssl-cbc-static-iv/php-openssl-cbc-static-iv_non-compliant.php
@@ -1,0 +1,17 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-openssl-cbc-static-iv@v1.0 defects=1}
+function nonCompliant2($plaintext, $password) {
+    $key = hash('sha256', $password, true);
+    $iv = "4c25ecc95c8816db753cba44a3b56aca";
+// Noncompliant : Hardcoded `vi` value in initialization vector.   
+    $ciphertext = openssl_encrypt($plaintext, "AES-256-CBC", $key, OPENSSL_RAW_DATA, $iv);
+    $hash = hash_hmac('sha256', $ciphertext . $iv, $key, true);
+    return $iv . $hash . $ciphertext;
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-openssl-decrypt-validate/php-openssl-decrypt-validate_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-openssl-decrypt-validate/php-openssl-decrypt-validate_compliant.php
@@ -1,0 +1,21 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-openssl-decrypt-validate@v1.0 defects=0}
+// Compliant: Validates the result of `openssl_decrypt()` by checking for `false` return, ensuring proper handling of decryption failures.
+class OpenSslTest {
+    public static function decryptData($ciphertext, $key) {
+        $decodedKey = html_entity_decode($key);
+        $iv = openssl_random_pseudo_bytes(16);
+        $decryptedData = openssl_decrypt($ciphertext, "AES-128-CBC", $decodedKey, 0, $iv);
+        if ($decryptedData === false) {
+            return "";
+        }
+        return $decryptedData;
+    }
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-openssl-decrypt-validate/php-openssl-decrypt-validate_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-openssl-decrypt-validate/php-openssl-decrypt-validate_non-compliant.php
@@ -1,0 +1,21 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-openssl-decrypt-validate@v1.0 defects=1}
+// Noncompliant: Incorrectly checks for `true` as the failure condition for `openssl_decrypt()`, potentially mishandling decryption failures.
+class OpenSslTest {
+    public static function nonCompliant3($ciphertext, $key) {
+        $decodedKey = html_entity_decode($key);
+        $iv = openssl_random_pseudo_bytes(16); 
+        $decryptedData = openssl_decrypt($ciphertext, "AES-128-CBC", $decodedKey, 0, $iv);
+        if ($decryptedData === true) {
+            return "Decryption failed"; 
+        }
+        return $decryptedData;
+    }
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-os-command-injection/php-os-command-injection_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-os-command-injection/php-os-command-injection_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-os-command-injection@v1.0 defects=0}
+$fullpath = $_POST['fullpath'];
+// Compliant: `escapeshellarg()` is used to prevent command injection.
+$filesize = trim(shell_exec('stat -c %s ' . escapeshellarg($fullpath)));
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-os-command-injection/php-os-command-injection_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-os-command-injection/php-os-command-injection_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-os-command-injection@v1.0 defects=1}
+$username = $_COOKIE['username'];
+// Noncompliant: Incorporating variable into command strings.
+exec("wto -n \"$username\" -g", $ret);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-path-traversal/php-path-traversal_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-path-traversal/php-path-traversal_compliant.php
@@ -1,0 +1,16 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-path-traversal@v1.0 defects=0}
+// Compliant: Uses `realpath()` to validate the final path, preventing directory traversal attacks by ensuring the expected path.
+$user_input_compliant_3 = 'subdirectory/../file.txt';
+$path = BASE_PATH . "/" . $user_input_compliant_3;
+if(realpath($path) !== BASE_PATH . $user_input_compliant_3) {
+  die("Invalid path");
+}
+$json = file_get_contents($path); 
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-path-traversal/php-path-traversal_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-path-traversal/php-path-traversal_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-path-traversal@v1.0 defects=1}
+// Noncompliant: Directly uses unvalidated user input, allowing potential path traversal attacks to access unauthorized files.
+$user_input_noncompliant_3 = '.../...//';
+$json = file_get_contents($user_input_noncompliant_3);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-permissive-cors/php-permissive-cors_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-permissive-cors/php-permissive-cors_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-permissive-cors@v1.0 defects=0}
+// Compliant: Custom header with a wildcard value does not pose a risk to cross-origin communication.
+header("Other-Properties: *");
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-permissive-cors/php-permissive-cors_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-permissive-cors/php-permissive-cors_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-permissive-cors@v1.0 defects=1}
+// Noncompliant: `Access-Control-Allow-Origin` header to `*` can allow any origin to access sensitive resources without proper verification.
+header('Access-Control-Allow-Origin: *');
+// {/fact}
+
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-phpinfo-use/php-phpinfo-use.php_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-phpinfo-use/php-phpinfo-use.php_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-phpinfo-use@v1.0 defects=1}
+// Noncompliant: Calls and outputs `phpinfo()`, potentially exposing sensitive system and configuration information to unauthorized users.
+echo phpinfo();
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-phpinfo-use/php-phpinfo-use_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-phpinfo-use/php-phpinfo-use_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-phpinfo-use@v1.0 defects=0}
+// Compliant: Echoes a string instead of calling the `phpinfo()` function, avoiding exposure of sensitive system information.
+echo "phpinfo";
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-phpmailer-smtp-insecure/php-phpmailer-smtp-insecure_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-phpmailer-smtp-insecure/php-phpmailer-smtp-insecure_compliant.php
@@ -1,0 +1,13 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-phpmailer-smtp-insecure@v1.0 defects=0}
+// Compliant: Uses SSL encryption for SMTP communication by specifying `ssl://` in the host address, ensuring secure data transmission.
+use PHPMailer\PHPMailer\PHPMailer;
+$secureMailClient = new PHPMailer(true);
+$secureMailClient->Host = 'ssl://secure-mail.com';
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-phpmailer-smtp-insecure/php-phpmailer-smtp-insecure_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-phpmailer-smtp-insecure/php-phpmailer-smtp-insecure_non-compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-phpmailer-smtp-insecure@v1.0 defects=1}
+// Noncompliant: Sets `SMTPSecure` to an empty string, disabling encryption for SMTP communication and exposing email data to potential interception.
+use PHPMailer\PHPMailer\PHPMailer;
+$vulnerableMailClient = new PHPMailer(true);
+$vulnerableMailClient->Host = 'vulnerable-host.com';
+$vulnerableMailClient->SMTPSecure = '';
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-redirect-to-request-uri/php-redirect-to-request-uri_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-redirect-to-request-uri/php-redirect-to-request-uri_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-redirect-to-request-uri@v1.0 defects=0}
+// Compliant: Secure way to redirect users to the current script itself without opening up the possibility of an open redirect.
+$currentScript = $_SERVER['PHP_SELF'];
+header('Location: ' . $currentScript);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-redirect-to-request-uri/php-redirect-to-request-uri_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-redirect-to-request-uri/php-redirect-to-request-uri_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-redirect-to-request-uri@v1.0 defects=1}
+// Noncompliant: `$_SERVER["REQUEST_URI"]` directly in the `Location` header can potentially introduce an open redirect vulnerability.
+header("location: ".$_SERVER['REQUEST_URI'].'/');
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-secure-signal-handling/php-secure-signal-handling_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-secure-signal-handling/php-secure-signal-handling_compliant.php
@@ -1,0 +1,16 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-secure-signal-handling@v1.0 defects=0}
+function terminateProcess($param)  {
+    $processId = (int)$_GET["pid"];
+    // Compliant: Kills the process with validation.
+    if (isValidPid($processId)) {
+        pcntl_signal($processId, 9);
+    }
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-secure-signal-handling/php-secure-signal-handling_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-secure-signal-handling/php-secure-signal-handling_non-compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-secure-signal-handling@v1.0 defects=1}
+function terminateProcessWithoutValidation($param)  {
+    $processId = (int)$_GET["pid"];
+    // Noncompliant: Kills the process without validation.
+    pcntl_signal($processId, 9);
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-sensitive-file-permission/php-sensitive-file-permission_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-sensitive-file-permission/php-sensitive-file-permission_compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-sensitive-file-permission@v1.0 defects=0}
+// Compliant: Used more restrictive file permissions `0750`.
+setFilePermissionsCompliant("foo", 0750);
+function setFilePermissionsCompliant($filePath, $permissions) {
+    chmod($filePath, $permissions);
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-sensitive-file-permission/php-sensitive-file-permission_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-sensitive-file-permission/php-sensitive-file-permission_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-sensitive-file-permission@v1.0 defects=1}
+$fileSystem = new Filesystem();
+// Noncompliant: `0777` as it gives full read, write, and execute permissions to all users, which can be a security risk.
+$fileSystem->chmod("foo", 0777);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-ssrf/php-ssrf_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-ssrf/php-ssrf_compliant.php
@@ -1,0 +1,13 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-ssrf@v1.0 defects=0}
+// Compliant: Uses a hardcoded local file path, preventing Server-Side Request Forgery by not allowing user input to influence the file location.
+function openFile() {
+    $fileHandle = fopen("/tmp/test.txt", 'rb');
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-ssrf/php-ssrf_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-ssrf/php-ssrf_non-compliant.php
@@ -1,0 +1,13 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-ssrf@v1.0 defects=1}
+// Noncompliant: Directly uses unvalidated user input, potentially allowing Server-Side Request Forgery (SSRF) attacks.
+function initializeCurlRequest() {
+    $curlHandle = curl_init($_GET['req']);
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-symfony-csrf-protection-disabled/php-symfony-csrf-protection-disabled_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-symfony-csrf-protection-disabled/php-symfony-csrf-protection-disabled_compliant.php
@@ -1,0 +1,21 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-symfony-csrf-protection-disabled@v1.0 defects=0}
+use Symfony\Component\Form\AbstractType;
+// Compliant: `CSRF` protection enabled.
+class Type extends AbstractType
+{
+  public function configureOptions(OptionsResolver $resolver)
+  {
+    $csrfResolver = $resolver; // Standardized variable name
+    $csrfResolver->setDefaults([
+        'csrf_protection' => true
+    ]);
+  }
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-symfony-csrf-protection-disabled/php-symfony-csrf-protection-disabled_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-symfony-csrf-protection-disabled/php-symfony-csrf-protection-disabled_non-compliant.php
@@ -1,0 +1,21 @@
+<?php
+
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+use Symfony\Component\Form\AbstractType;
+// {fact rule=php-symfony-csrf-protection-disabled@v1.0 defects=1}
+// Noncompliant: `CSRF` protection is disabled.
+class Type extends AbstractType
+{
+  public function configureOptions(OptionsResolver $resolver)
+  {
+    $csrfResolver = $resolver; // Standardized variable name
+    $csrfResolver->setDefaults(array(
+        'csrf_protection' => false
+    ));
+  }
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-symfony-non-literal-redirect/php-symfony-non-literal-redirect_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-symfony-non-literal-redirect/php-symfony-non-literal-redirect_compliant.php
@@ -1,0 +1,19 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-symfony-non-literal-redirect@v1.0 defects=0}
+// Compliant: Uses `redirectToRoute()` method, which internally validates and constructs the URL, mitigating risks associated with open redirects.
+use Symfony\Component\HttpFoundation\RedirectResponse;
+class WebAppController
+{
+    public function compliantRedirect(): RedirectResponse
+    {
+        $foo = $session->get('foo');
+        return $this->redirectToRoute($foo);
+    }
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-symfony-non-literal-redirect/php-symfony-non-literal-redirect_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-symfony-non-literal-redirect/php-symfony-non-literal-redirect_non-compliant.php
@@ -1,0 +1,19 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-symfony-non-literal-redirect@v1.0 defects=1}
+// Noncompliant: Uses `redirect()` with unvalidated user input, potentially allowing open redirect vulnerabilities.
+use Symfony\Component\HttpFoundation\RedirectResponse;
+class WebAppController
+{
+    public function nonCompliantRedirect(): RedirectResponse
+    {
+        $foo = $session->get('foo');
+        return $this->redirect($foo);
+    }
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-symfony-permissive-cors/php-symfony-permissive-cors_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-symfony-permissive-cors/php-symfony-permissive-cors_compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-symfony-permissive-cors@v1.0 defects=0}
+// Compliant: Uses predefined safe headers instead of allowing all origins, preventing overly permissive CORS settings.
+namespace Symfony;
+use Symfony\Component\HttpFoundation\Response;
+$safeHeaders = ['foo' => 'bar'];
+$response = new Response('context', Response::HTTP_OK, $safeHeaders);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-symfony-permissive-cors/php-symfony-permissive-cors_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-symfony-permissive-cors/php-symfony-permissive-cors_non-compliant.php
@@ -1,0 +1,13 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-symfony-permissive-cors@v1.0 defects=1}
+// Noncompliant: Sets `access-control-allow-origin` header to `*`, allowing unrestricted cross-origin access and potentially exposing sensitive data.
+namespace Symfony;
+use Symfony\Component\HttpFoundation\Response;
+$response = new Response('context', Response::HTTP_OK, ['access-control-allow-origin' => '*']);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-filename/php-tainted-filename_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-filename/php-tainted-filename_compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-tainted-filename@v1.0 defects=0}
+// Compliant: Uses tainted filename as the parameter in `hash_file()`, not as the filename, preventing potential path traversal attacks.
+$taintedFilename = $_GET["tainted"];
+hash_file($taintedFilename, 'test.txt');
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-filename/php-tainted-filename_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-filename/php-tainted-filename_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-tainted-filename@v1.0 defects=1}
+// Noncompliant: Uses unvalidated user input directly as a filename in `hash_file()`, potentially allowing path traversal attacks.
+$taintedFilename = $_GET["tainted"];
+hash_file('sha1', $taintedFilename);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-object-instantiation/php-tainted-object-instantiation_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-object-instantiation/php-tainted-object-instantiation_compliant.php
@@ -1,0 +1,13 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-tainted-object-instantiation@v1.0 defects=0}
+// Compliant: Uses a hardcoded class name for instantiation, preventing potential object injection vulnerabilities.
+$controllerClassName = "MyController";
+$controllerInstance = new $controllerClassName();
+// {/fact}
+
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-object-instantiation/php-tainted-object-instantiation_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-object-instantiation/php-tainted-object-instantiation_non-compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-tainted-object-instantiation@v1.0 defects=1}
+// Noncompliant: Uses unvalidated user input to dynamically instantiate objects, potentially allowing object injection attacks.
+$pathParts = explode("/", $_REQUEST['PATH_INFO']);
+$controllerClassName = $pathParts[0];
+$controllerInstance = new $controllerClassName($pathParts[1]);
+// {/fact}
+
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-session/php-tainted-session_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-session/php-tainted-session_compliant.php
@@ -1,0 +1,15 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-tainted-session@v1.0 defects=0}
+// Compliant: The session prefix is used to prevent tainted session input.
+session_start();
+$sessionPrefix = 'prefix'; 
+$userInput = $_GET['input'];
+$_SESSION[$sessionPrefix . $userInput] = true;
+//{/fact}
+
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-session/php-tainted-session_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-session/php-tainted-session_non-compliant.php
@@ -1,0 +1,13 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-tainted-session@v1.0 defects=1}
+// Noncompliant: The tainted session variable is used in a session.
+session_start();
+$userInput = $_GET['input']; 
+$_SESSION[$userInput] = true;
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-url-host/php-tainted-url-host_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-url-host/php-tainted-url-host_compliant.php
@@ -1,0 +1,22 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-tainted-url-host@v1.0 defects=0}
+function makeRequest($url) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    $data = curl_exec($ch);
+    curl_close($ch);
+    return $data;
+}
+// Compliant: Sanitizes user input with `htmlspecialchars()` before using it in URL construction, preventing potential URL manipulation attacks.
+function compliant() {
+    $url = 'https://www.google.com/' . htmlspecialchars($_POST['url'], ENT_QUOTES, 'UTF-8') . '/foobar';
+    $info = makeRequest($url);
+    return $info;
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-tainted-url-host/php-tainted-url-host_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-tainted-url-host/php-tainted-url-host_non-compliant.php
@@ -1,0 +1,22 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-tainted-url-host@v1.0 defects=1}
+// Noncompliant: Uses unsanitized user input directly in URL construction, potentially allowing URL manipulation and SSRF attacks.
+function makeRequest($url) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    $data = curl_exec($ch);
+    curl_close($ch);
+    return $data;
+}
+function nonCompliant() {
+    $url = 'https://' . $_POST['url'] . '/foobar'; 
+    $info = makeRequest($url);
+    return $info;
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-using-pseudorandom-number/php-using-pseudorandom-number_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-using-pseudorandom-number/php-using-pseudorandom-number_compliant.php
@@ -1,0 +1,12 @@
+
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-using-pseudorandom-number@v1.0 defects=0}
+// Compliant: Securely generate random number.
+$secureRandomNumber = random_bytes(16);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-using-pseudorandom-number/php-using-pseudorandom-number_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-using-pseudorandom-number/php-using-pseudorandom-number_non-compliant.php
@@ -1,0 +1,12 @@
+
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-using-pseudorandom-number@v1.0 defects=1}
+// Noncompliant: Insecure way of generating random number.
+$insecureRandomNumber = mt_rand();
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-weak-crypto/php-weak-crypto_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-weak-crypto/php-weak-crypto_compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-weak-crypto@v1.0 defects=0}
+// Compliant: `SHA-256` is a secure hashing algorithm.
+function setUserPassword($value) {
+    $hashedPassword = hash('sha256', $value);
+    $user->setPassword($hashedPassword);
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-weak-crypto/php-weak-crypto_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-weak-crypto/php-weak-crypto_non-compliant.php
@@ -1,0 +1,14 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-weak-crypto@v1.0 defects=1}
+// Noncompliant: Weak hashing algorithm `MD5` is used.
+function setUserPasswordWeak($value) { 
+    $hashedPassword = hash('md5', $value);
+    $user->setPassword($hashedPassword);
+}
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-ajax-no-auth-and-auth-hooks-audit/php-wp-ajax-no-auth-and-auth-hooks-audit_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-ajax-no-auth-and-auth-hooks-audit/php-wp-ajax-no-auth-and-auth-hooks-audit_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-ajax-no-auth-and-auth-hooks-audit@v1.0 defects=0}
+// Compliant: Uses `plugins_loaded` hook, which runs for all requests, avoiding potential security issues with AJAX-specific hooks.
+add_action('plugins_loaded', 'initializeUploadPlugins');
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-ajax-no-auth-and-auth-hooks-audit/php-wp-ajax-no-auth-and-auth-hooks-audit_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-ajax-no-auth-and-auth-hooks-audit/php-wp-ajax-no-auth-and-auth-hooks-audit_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-ajax-no-auth-and-auth-hooks-audit@v1.0 defects=1}
+// Noncompliant: Action hook for AJAX upload without proper authentication.
+add_action('wp_ajax_upload', 'unauthorizedUpload');
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-code-execution-audit/php-wp-code-execution-audit_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-code-execution-audit/php-wp-code-execution-audit_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-code-execution-audit@v1.0 defects=0}
+// Compliant: Calls a safe function without executing arbitrary code.
+safeFunction($args);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-code-execution-audit/php-wp-code-execution-audit_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-code-execution-audit/php-wp-code-execution-audit_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-code-execution-audit@v1.0 defects=1}
+// Noncompliant: Using `eval` to execute arbitrary code
+$codeSnippet = call_user_func('return ' . $sanitizedSnippet . ';');
+
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-csrf-audit/php-wp-csrf-audit_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-csrf-audit/php-wp-csrf-audit_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-csrf-audit@v1.0 defects=0}
+// Compliant: Uses `check_ajax_referer()` to verify the `nonce`, protecting against CSRF attacks in WordPress AJAX requests.
+check_ajax_referer( 'wpforms-admin', 'nonce' );
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-csrf-audit/php-wp-csrf-audit_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-csrf-audit/php-wp-csrf-audit_non-compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-csrf-audit@v1.0 defects=1}
+// Noncompliant: Uses `check_ajax_referer()` with die parameter set to `0`, allowing the request to continue even if the nonce check fails.
+check_ajax_referer( 'wpforms-admin', 'nonce', 0 );
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-open-redirect-audit/php-wp-open-redirect-audit_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-open-redirect-audit/php-wp-open-redirect-audit_compliant.php
@@ -1,0 +1,15 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-open-redirect-audit@v1.0 defects=0}
+// Compliant: Uses `wp_safe_redirect()` to handle redirects, preventing open redirect vulnerabilities by validating the URL.
+function handleRedirect()
+{
+    wp_safe_redirect($_POST['url']);
+    exit;
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-open-redirect-audit/php-wp-open-redirect-audit_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-open-redirect-audit/php-wp-open-redirect-audit_non-compliant.php
@@ -1,0 +1,16 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+//{fact rule=php-wp-open-redirect-audit@v1.0 defects=1}
+// Noncompliant: Uses `wp_redirect()` with unvalidated user input, potentially allowing open redirect vulnerabilities.
+function handleRedirect()
+{
+    $url = $_GET['url'];
+    wp_redirect($url);
+    exit;
+}
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-php-object-injection-audit/php-wp-php-object-injection-audit_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-php-object-injection-audit/php-wp-php-object-injection-audit_compliant.php
@@ -1,0 +1,13 @@
+
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-wp-php-object-injection-audit@v1.0 defects=0}
+// Compliant: Only unserialize trusted and validated data to prevent potential security risks
+$trustedData = 'O:1:"a":1:{s:5:"value";s:3:"100";}';
+$object = unserialize($trustedData);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-wp-php-object-injection-audit/php-wp-php-object-injection-audit_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-wp-php-object-injection-audit/php-wp-php-object-injection-audit_non-compliant.php
@@ -1,0 +1,13 @@
+
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-wp-php-object-injection-audit@v1.0 defects=1}
+// Noncompliant: Tainted `inputData` is used, leading to potential insecure deserialization vulnerabilities.
+$inputData = $_GET["inputData"];
+$object = unserialize($inputData);
+//{/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-zip-entry-check/php-zip-entry-check_compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-zip-entry-check/php-zip-entry-check_compliant.php
@@ -1,0 +1,11 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-zip-entry-check@v1.0 defects=0}
+// Compliant: `zipEntryRead` will read the next `1024` bytes of data from the zip entry starting from the current position.
+zipEntryRead($zip_entry, 1024); 
+// {/fact}
+?>

--- a/src/rule_based_detector_library/PHP/detectors/php-zip-entry-check/php-zip-entry-check_non-compliant.php
+++ b/src/rule_based_detector_library/PHP/detectors/php-zip-entry-check/php-zip-entry-check_non-compliant.php
@@ -1,0 +1,12 @@
+<?php
+/* 
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: MIT-0
+*/
+
+// {fact rule=php-zip-entry-check@v1.0 defects=1}
+// Noncompliant: The entire content of the zip entry is read and returned by `zipEntryRead`.
+$zip1 = new ZipArchive();
+$zip1->extractTo('.');
+// {/fact}
+?>


### PR DESCRIPTION
Add non compliant and compliant samples for PHP detectors.

Note: All the test cases have 100% recall and precision.