### PR TITLE
Added compliant and noncompliant DL case for python_cdk

### DIFF
--- a/python_cdk/src/detectors/python-cdk-api-logging-disabled/python-cdk-api-logging-disabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-api-logging-disabled/python-cdk-api-logging-disabled_compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-api-logging-disabled@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import aws_apigatewayv2
+
+
+class APILoggingDisabled(cdk.Stack):
+
+    def api_logging_disabled_compliant(self):
+        # Compliant: logging present.
+        aws_apigatewayv2.CfnStage(self, 'rStage',
+                                  access_log_settings=aws_apigatewayv2
+                                  .CfnStage.access_log_settingsProperty(
+                                      destination_arn='foo',
+                                      format='$context.requestId'),
+                                  api_id='bar',
+                                  stage_name='baz')
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-api-logging-disabled/python-cdk-api-logging-disabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-api-logging-disabled/python-cdk-api-logging-disabled_compliant.py
@@ -9,7 +9,7 @@ from aws_cdk import aws_apigatewayv2
 class APILoggingDisabled(cdk.Stack):
 
     def api_logging_disabled_compliant(self):
-        # Compliant: logging present.
+        # Compliant: logging enabled.
         aws_apigatewayv2.CfnStage(self, 'rStage',
                                   access_log_settings=aws_apigatewayv2
                                   .CfnStage.access_log_settingsProperty(

--- a/python_cdk/src/detectors/python-cdk-api-logging-disabled/python-cdk-api-logging-disabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-api-logging-disabled/python-cdk-api-logging-disabled_non-compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-api-logging-disabled@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import aws_apigatewayv2
+
+
+class APILoggingDisabled(cdk.Stack):
+
+    def api_logging_disabled_noncompliant(self):
+        # Noncompliant: logging disabled.
+        aws_apigatewayv2.CfnStage(self, 'rHttpApiDefaultStage',
+                                  api_id='foo', stage_name='$default',
+                                  auto_deploy=True)
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-aws-dynamodb-billing-mode/python-cdk-aws-dynamodb-billing-mode_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-aws-dynamodb-billing-mode/python-cdk-aws-dynamodb-billing-mode_compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-aws-dynamodb-billing-mode@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_dynamodb import Table, AttributeType,Attribute, BillingMode
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Compliant: `billing_mode` is set to `PAY_PER_REQUEST`.
+        Table(Stack, "GlobalTable", partition_key=Attribute(name="pk", type=AttributeType.STRING),billing_mode=BillingMode.PAY_PER_REQUEST)
+        # {/fact}

--- a/python_cdk/src/detectors/python-cdk-aws-dynamodb-billing-mode/python-cdk-aws-dynamodb-billing-mode_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-aws-dynamodb-billing-mode/python-cdk-aws-dynamodb-billing-mode_non-compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-aws-dynamodb-billing-mode@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_dynamodb import Table, AttributeType,Attribute
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Noncompliant: `billing_mode` is not set to `PAY_PER_REQUEST`.
+        Table(Stack, "GlobalTable", partition_key=Attribute(name="pk", type=AttributeType.STRING))
+        # {/fact}

--- a/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_compliant.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-ec-2-security-group-description@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_ec2 import SecurityGroup,Vpc
+
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Compliant: SecurityGroup description is set.
+        SecurityGroup(Stack, 'rSg', 
+            vpc= Vpc(Stack, 'rVpc'),
+            description= 'lorem ipsum dolor sit amet',
+        )
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_compliant.py
@@ -11,7 +11,7 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
 
-        # Compliant: SecurityGroup description is set.
+        # Compliant: Description set for the SecurityGroup.
         SecurityGroup(Stack, 'rSg', 
             vpc= Vpc(Stack, 'rVpc'),
             description= 'lorem ipsum dolor sit amet',

--- a/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_non-compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-ec-2-security-group-description@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_ec2 import SecurityGroup,Vpc
+from aws_cdk import aws_ec2 as ec2
+
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Noncompliant: SecurityGroup description contains an empty string.
+        SecurityGroup(Stack, 'rSg', 
+            vpc= Vpc(Stack, 'rVpc'),
+            description= ' ',
+        )
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec-2-security-group-description/python-cdk-ec-2-security-group-description_non-compliant.py
@@ -12,7 +12,7 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
 
-        # Noncompliant: SecurityGroup description contains an empty string.
+        # Noncompliant: The SecurityGroup instantiation includes an empty string as the description.
         SecurityGroup(Stack, 'rSg', 
             vpc= Vpc(Stack, 'rVpc'),
             description= ' ',

--- a/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_compliant.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-ec2-expose-selective-ports@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_ec2 import CfnSecurityGroupIngress
+
+
+class SelectivePorts(cdk.Stack):
+
+    def exposure_of_sensitive_information_compliant(self):
+        # Compliant: 0.0.0.0/0 range is not used.
+        CfnSecurityGroupIngress(cdk.Stack, 'rIngress',
+                                ip_protocol='tcp',
+                                cidr_ip='1.2.3.4/32')
+
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_compliant.py
@@ -9,7 +9,7 @@ from aws_cdk.aws_ec2 import CfnSecurityGroupIngress
 class SelectivePorts(cdk.Stack):
 
     def exposure_of_sensitive_information_compliant(self):
-        # Compliant: 0.0.0.0/0 range is not used.
+        # Compliant: The CfnSecurityGroupIngress instantiation does not use the 0.0.0.0/0 range.
         CfnSecurityGroupIngress(cdk.Stack, 'rIngress',
                                 ip_protocol='tcp',
                                 cidr_ip='1.2.3.4/32')

--- a/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_non-compliant.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-ec2-expose-selective-ports@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_ec2 import CfnSecurityGroupIngress
+
+
+class SelectivePorts(cdk.Stack):
+
+    def exposure_of_sensitive_information_noncompliant(self):
+        # Noncompliant: 0.0.0.0/0 range is used.
+        CfnSecurityGroupIngress(cdk.Stack, 'rIngress',
+                                ip_protocol='tcp',
+                                cidr_ip='0.0.0.0/0')
+
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-ec2-expose-selective-ports/python-cdk-ec2-expose-selective-ports_non-compliant.py
@@ -9,7 +9,7 @@ from aws_cdk.aws_ec2 import CfnSecurityGroupIngress
 class SelectivePorts(cdk.Stack):
 
     def exposure_of_sensitive_information_noncompliant(self):
-        # Noncompliant: 0.0.0.0/0 range is used.
+        # Noncompliant: The CfnSecurityGroupIngress instantiation uses the 0.0.0.0/0 range.
         CfnSecurityGroupIngress(cdk.Stack, 'rIngress',
                                 ip_protocol='tcp',
                                 cidr_ip='0.0.0.0/0')

--- a/python_cdk/src/detectors/python-cdk-elasticache-cluster-usage-of-default-port/python-cdk-elasticache-cluster-usage-of-default-port_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elasticache-cluster-usage-of-default-port/python-cdk-elasticache-cluster-usage-of-default-port_compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-elasticache-cluster-usage-of-default-port@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_elasticache import CfnCacheCluster
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Compliant: ElastiCache cluster uses the default endpoint port.
+    CfnCacheCluster(
+        self, "rAec",
+        cache_node_type="cache.t3.micro",
+        engine="memcached",
+        num_cache_nodes=42,
+        port=42  
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-elasticache-cluster-usage-of-default-port/python-cdk-elasticache-cluster-usage-of-default-port_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elasticache-cluster-usage-of-default-port/python-cdk-elasticache-cluster-usage-of-default-port_non-compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-elasticache-cluster-usage-of-default-port@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_elasticache import CfnCacheCluster
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+    # Noncompliant: ElastiCache cluster does not uses the default endpoint port.
+    CfnCacheCluster(
+        self, "rAec",
+        cache_node_type="cache.t3.micro",
+        engine="memcached", 
+        num_cache_nodes=42,
+        port=11211
+    )
+    # {/fact}
+

--- a/python_cdk/src/detectors/python-cdk-elasticache-missing-redis-authorization/python-cdk-elasticache-missing-redis-authorization_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elasticache-missing-redis-authorization/python-cdk-elasticache-missing-redis-authorization_compliant.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-elasticache-missing-redis-authorization@v1.0 defects=0}
+from aws_cdk import cdk
+from aws_cdk.aws_elasticache import CfnReplicationGroup
+from aws_cdk import aws_elasticache as elasticache
+
+class CdkStarterStack(core.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+        # Compliant: `transit_encryption_enabled` is enabled.
+        CfnReplicationGroup(self, "rRedisGroup",
+            cache_node_type="cache.t3.micro",
+            replication_group_description="lorem ipsum dolor sit amet",
+            cache_subnet_group_name="lorem",
+            transit_encryption_enabled=True,
+            auth_token="secret",  
+            port=42
+        )
+        # {/fact}
+
+     

--- a/python_cdk/src/detectors/python-cdk-elasticache-missing-redis-authorization/python-cdk-elasticache-missing-redis-authorization_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elasticache-missing-redis-authorization/python-cdk-elasticache-missing-redis-authorization_non-compliant.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-elasticache-missing-redis-authorization@v1.0 defects=1}
+from aws_cdk import cdk
+from aws_cdk.aws_elasticache import CfnReplicationGroup
+from aws_cdk import aws_elasticache as elasticache
+
+class CdkStarterStack(core.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Noncompliant: `transit_encryption_enabled` is disabled.
+        CfnReplicationGroup(self, "rRedisGroup",
+            cache_node_type="cache.t3.micro",
+            engine="redis", 
+            replication_group_description="lorem ipsum dolor sit amet"
+        )
+        # {/fact}
+
+        

--- a/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_compliant.py
@@ -10,7 +10,7 @@ from aws_cdk import aws_elasticloadbalancing as elb
 class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
-    # Compliant: `LoadBalancingProtocol` is set.
+    # Compliant: The LoadBalancingProtocol is set to ssl for the both the protocol.
     LoadBalancer(self, 'rELB1', 
         vpc= Vpc(self, 'rVPC'),
     ).add_listener(

--- a/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_compliant.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-elb-tls-https-listeners-only@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack, Vpc
+from aws_cdk.aws_elasticloadbalancing import LoadBalancer,LoadBalancingProtocol
+from aws_cdk import aws_elasticloadbalancing as elb
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+    # Compliant: `LoadBalancingProtocol` is set.
+    LoadBalancer(self, 'rELB1', 
+        vpc= Vpc(self, 'rVPC'),
+    ).add_listener(
+        internal_protocol= LoadBalancingProtocol.ssl,
+        external_port= 42,
+        external_protocol= LoadBalancingProtocol.ssl,
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_non-compliant.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-elb-tls-https-listeners-only@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack, Vpc
+from aws_cdk.aws_elasticloadbalancing import LoadBalancer,LoadBalancingProtocol
+from aws_cdk import aws_elasticloadbalancing as elb
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+    # Noncompliant: `LoadBalancingProtocol` is not set.
+    LoadBalancer(self, 'rELB',
+        vpc= Vpc(self, 'rVPC'),
+    ).add_listener(
+        internal_protocol= LoadBalancingProtocol.tcp,
+        external_port= 42,
+        external_protocol= LoadBalancingProtocol.ssl,
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-elb-tls-https-listeners-only/python-cdk-elb-tls-https-listeners-only_non-compliant.py
@@ -10,7 +10,7 @@ from aws_cdk import aws_elasticloadbalancing as elb
 class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
-    # Noncompliant: `LoadBalancingProtocol` is not set.
+    # Noncompliant: The LoadBalancingProtocol is set to tcp for the internal protocol.
     LoadBalancer(self, 'rELB',
         vpc= Vpc(self, 'rVPC'),
     ).add_listener(

--- a/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_compliant.py
@@ -12,7 +12,7 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)   
         
-    # Compliant: `kerberos_attributes` is set.
+    # Compliant: The CfnCluster instantiation sets the kerberos_attributes property with KerberosAttributesProperty, including kdc_admin_password and realm.
     CfnCluster(self, 'rEmrCluster', 
         instances= InstanceGroupConfigProperty(),
         job_flow_role= ' EMR_EC2_DefaultRole',

--- a/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_compliant.py
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-emr-auth-ec-2-key-pair-or-kerberos@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_emr import CfnCluster
+from aws_cdk.aws_emr.CfnCluster import InstanceGroupConfigProperty,KerberosAttributesProperty
+from aws_cdk import aws_emr as emr
+	 
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)   
+        
+    # Compliant: `kerberos_attributes` is set.
+    CfnCluster(self, 'rEmrCluster', 
+        instances= InstanceGroupConfigProperty(),
+        job_flow_role= ' EMR_EC2_DefaultRole',
+        name= 'foo',
+        serviceRole= 'bar',
+        kerberos_attributes=KerberosAttributesProperty(
+        kdc_admin_password= 'baz',
+        realm= 'qux',
+        ),
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_non-compliant.py
@@ -12,7 +12,7 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)   
         
-    # Noncompliant: `kerberos_attributes` is not set.
+    # Noncompliant: The CfnCluster instantiation does not set the kerberos_attributes property.
     CfnCluster(self, 'rEmrCluster',
         instances = InstanceGroupConfigProperty() ,
         job_flow_role= ' EMR_EC2_DefaultRole',

--- a/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emr-auth-ec-2-key-pair-or-kerberos/python-cdk-emr-auth-ec-2-key-pair-or-kerberos_non-compliant.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-emr-auth-ec-2-key-pair-or-kerberos@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_emr import CfnCluster
+from aws_cdk.aws_emr.CfnCluster import InstanceGroupConfigProperty,KerberosAttributesProperty
+from aws_cdk import aws_emr as emr
+	 
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)   
+        
+    # Noncompliant: `kerberos_attributes` is not set.
+    CfnCluster(self, 'rEmrCluster',
+        instances = InstanceGroupConfigProperty() ,
+        job_flow_role= ' EMR_EC2_DefaultRole',
+        name= 'foo',
+        serviceRole= 'bar',
+    )
+   

--- a/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-emrs-3-access-logging@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_emr import CfnCluster
+from aws_cdk import aws_emr as emr
+
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)
+      # Compliant: `log_uri` is set.
+      CfnCluster(self, 'rEmrCluster', job_flow_role = ' EMR_EC2_DefaultRole', name = 'foo', service_role = 'bar', log_uri= 'baz')
+      
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_compliant.py
@@ -10,7 +10,7 @@ from aws_cdk import aws_emr as emr
 class CdkStarterself(cdk.self):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)
-      # Compliant: `log_uri` is set.
+      # Compliant: The CfnCluster instantiation sets the `log_uri` property.
       CfnCluster(self, 'rEmrCluster', job_flow_role = ' EMR_EC2_DefaultRole', name = 'foo', service_role = 'bar', log_uri= 'baz')
       
 # {/fact}

--- a/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_non-compliant.py
@@ -11,8 +11,7 @@ class CdkStarterself(cdk.self):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)
 
-      # Noncompliant: `log_uri` is not set.
+      # Noncompliant: The CfnCluster instantiation does not set the log_uri property.
       CfnCluster(self, 'rEmrCluster', job_flow_role="jobFlowRole", name ='foo', service_role= 'bar')  
-      CfnCluster(self, 'rEmrCluster', job_flow_role="jobFlowRole", name ='foo',service_role= 'bar')
       
 # {/fact}

--- a/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-emrs-3-access-logging/python-cdk-emrs-3-access-logging_non-compliant.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-emrs-3-access-logging@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_emr import CfnCluster
+from aws_cdk import aws_emr as emr
+
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)
+
+      # Noncompliant: `log_uri` is not set.
+      CfnCluster(self, 'rEmrCluster', job_flow_role="jobFlowRole", name ='foo', service_role= 'bar')  
+      CfnCluster(self, 'rEmrCluster', job_flow_role="jobFlowRole", name ='foo',service_role= 'bar')
+      
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-internet-access-enabled-for-sagemaker-notebook/python-cdk-internet-access-enabled-for-sagemaker-notebook_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-internet-access-enabled-for-sagemaker-notebook/python-cdk-internet-access-enabled-for-sagemaker-notebook_compliant.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-internet-access-enabled-for-sagemaker-notebook@v1.0 defects=0}
+from aws_cdk import aws_sagemaker as sagemaker
+import aws_cdk as cdk
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Compliant: `direct_internet_access` is disabled.
+        sagemaker.CfnNotebookInstance(self, "rNotebook", 
+            instance_type="ml.t3.xlarge",
+            role_arn=iam.Role(self, "rNotebookRole",
+                assumed_by=iam.ServicePrincipal("sagemaker.amazonaws.com")
+            ).role_arn,
+            subnet_id="subnet-0bb1c79de3EXAMPLE",
+            direct_internet_access="Disabled"
+        )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-internet-access-enabled-for-sagemaker-notebook/python-cdk-internet-access-enabled-for-sagemaker-notebook_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-internet-access-enabled-for-sagemaker-notebook/python-cdk-internet-access-enabled-for-sagemaker-notebook_non-compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-internet-access-enabled-for-sagemaker-notebook@v1.0 defects=1}
+from aws_cdk import aws_sagemaker as sagemaker
+import aws_cdk as cdk
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Noncompliant: `direct_internet_access` is set to default.
+        sagemaker.CfnNotebookInstance(self, "rNotebook",
+            instance_type="ml.t3.xlarge",
+            role_arn=iam.Role(
+                self, "rNotebookRole",
+                assumed_by=iam.ServicePrincipal("sagemaker.amazonaws.com")
+            ).role_arn
+        )
+        #{/fact}

--- a/python_cdk/src/detectors/python-cdk-kmskey-encryption/python-cdk-kmskey-encryption_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-kmskey-encryption/python-cdk-kmskey-encryption_compliant.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-kmskey-encryption@v1.0 defects=0}
+import aws_cdk
+from aws_cdk.aws_codebuild import Project
+from aws_cdk.aws_codebuild import BuildSpec
+from aws_cdk import Stack
+from aws_cdk.aws_kms import Key
+
+class KMSKeyEncryption:
+  def __init__(self):
+    # Compliant: KMS key specified for encryption.
+    Project(Stack, "rBuildProject", build_spec=BuildSpec.from_object_to_yaml({
+        "version": 0.2,
+        "phases": {
+          "build": {
+            "commands": ['echo "foo"'],
+          },
+        },
+      }),
+      encryption_key=Key(Stack, "rBuildKey"))
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-kmskey-encryption/python-cdk-kmskey-encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-kmskey-encryption/python-cdk-kmskey-encryption_non-compliant.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-kmskey-encryption@v1.0 defects=1}
+import aws_cdk
+from aws_cdk.aws_codebuild import Project
+from aws_cdk.aws_codebuild import BuildSpec
+from aws_cdk import Stack
+from aws_cdk.aws_kms import Key
+
+class KMSKeyEncryption:
+  def __init__(self):
+
+    # Noncompliant: No KMS key specified for encryption.
+    Project(Stack, "rBuildProject", build_spec=BuildSpec.from_object_to_yaml({
+        "version": 0.2,
+        "phases": {
+          "build": {
+            "commands": ['echo "foo"'],
+          },
+        },
+      }))
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-lambda-latest-version/python-cdk-lambda-latest-version_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-lambda-latest-version/python-cdk-lambda-latest-version_compliant.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-lambda-latest-version@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_lambda import Code, Function
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Compliant: Lambda functions uses the latest runtime version.
+    Function(self, 'rFunction', 
+    runtime = get_latest_runtime('nodejs'),
+    code = Code.from_asset('hi'),
+    handler = 'index.handler'
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-lambda-latest-version/python-cdk-lambda-latest-version_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-lambda-latest-version/python-cdk-lambda-latest-version_non-compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-lambda-latest-version@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_lambda import CfnFunction, Runtime
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Noncompliant: Lambda function is not using the latest runtime version.
+    CfnFunction(self, 'rFunction', 
+    runtime = str(Runtime.NODEJS_16_X),
+    code = CfnFunction.CodeProperty(
+        s3_bucket="s3Bucket"
+    ),
+    role = 'somerole'
+    )
+   

--- a/python_cdk/src/detectors/python-cdk-msk-broker-to-broker-tls/python-cdk-msk-broker-to-broker-tls_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-msk-broker-to-broker-tls/python-cdk-msk-broker-to-broker-tls_compliant.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-msk-broker-to-broker-tls@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_msk import CfnCluster
+from aws_cdk.aws_msk.CfnCluster import BrokerNodeGroupInfoProperty,EncryptionInTransitProperty
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        (scope, id)    
+        # Compliant: EncryptionInTransitProperty's `in_cluster` is set to `True`.
+        CfnCluster(Stack, 'rMsk',
+            cluster_ame= 'foo',
+            kafka_version= '2.8.0',
+            broker_node_group_info= BrokerNodeGroupInfoProperty(
+            client_subnets= ['bar'],
+            instance_type= 'kafka.m5.large',
+            ),
+            number_of_broker_nodes= 42,
+            encryption_info= EncryptionInfoProperty(  encryption_in_transit=EncryptionInTransitProperty( in_cluster= True ) ),
+        )
+        #{/fact}
+       

--- a/python_cdk/src/detectors/python-cdk-msk-broker-to-broker-tls/python-cdk-msk-broker-to-broker-tls_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-msk-broker-to-broker-tls/python-cdk-msk-broker-to-broker-tls_non-compliant.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-msk-broker-to-broker-tls@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_msk import CfnCluster
+from aws_cdk.aws_msk.CfnCluster import BrokerNodeGroupInfoProperty,EncryptionInTransitProperty
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        (scope, id)    
+       
+       # Noncompliant: EncryptionInTransitProperty's `in_cluster` is set to `False`.
+        CfnCluster(Stack, 'rMsk', 
+            cluster_ame= 'foo',
+            kafka_version= '2.8.0',
+            broker_node_group_info= BrokerNodeGroupInfoProperty(
+            client_subnets= ['bar'],
+            instance_type= 'kafka.m5.large',
+            ),
+            number_of_broker_nodes= 42,
+            encryption_info= EncryptionInfoProperty(  encryption_in_transit=EncryptionInTransitProperty( in_cluster= False ) ),
+        )
+        #{/fact}

--- a/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_compliant.py
@@ -9,7 +9,7 @@ from aws_cdk.aws_neptune import CfnDBInstance
 class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)    
-    # Compliant: `auto_minor_version_upgrade` is set.
+    # Compliant: The CfnDBInstance instantiation sets the `auto_minor_version_upgrade` property to True.
     CfnDBInstance(Stack, 'rDatabaseInstance', 
         db_instance_class= 'db.r4.2xlarge',
         auto_minor_version_upgrade= True,

--- a/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_compliant.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-neptune-cluster-automatic-minor-version-upgrade@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_neptune import CfnDBInstance
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)    
+    # Compliant: `auto_minor_version_upgrade` is set.
+    CfnDBInstance(Stack, 'rDatabaseInstance', 
+        db_instance_class= 'db.r4.2xlarge',
+        auto_minor_version_upgrade= True,
+    ) 
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_non-compliant.py
@@ -9,7 +9,7 @@ from aws_cdk.aws_neptune import CfnDBInstance
 class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)    
-    # Noncompliant: `auto_minor_version_upgrade` is not set.
+    # Noncompliant: The CfnDBInstance instantiation does not set the `auto_minor_version_upgrade` property.
     CfnDBInstance(Stack, 'rDatabaseInstance', 
         db_instance_class= 'db.r4.2xlarge',
     )

--- a/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-neptune-cluster-automatic-minor-version-upgrade/python-cdk-neptune-cluster-automatic-minor-version-upgrade_non-compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-neptune-cluster-automatic-minor-version-upgrade@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_neptune import CfnDBInstance
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)    
+    # Noncompliant: `auto_minor_version_upgrade` is not set.
+    CfnDBInstance(Stack, 'rDatabaseInstance', 
+        db_instance_class= 'db.r4.2xlarge',
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_compliant.py
@@ -11,6 +11,6 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)
 
-      # Compliant: `encryption_at_rest_options` is set.
+      # Compliant: The LegacyCfnDomain instantiation sets the encryption_at_rest_options property with EncryptionAtRestOptionsProperty, enabling encryption at rest.
       LegacyCfnDomain(self, 'Domain',encryption_at_rest_options= EncryptionAtRestOptionsProperty(enabled=True))
       # {/fact}

--- a/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-open-search-encrypted-at-rest@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_opensearchservice import EncryptionAtRestOptionsProperty
+from aws_cdk.aws_elasticsearch import CfnDomain as LegacyCfnDomain
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)
+
+      # Compliant: `encryption_at_rest_options` is set.
+      LegacyCfnDomain(self, 'Domain',encryption_at_rest_options= EncryptionAtRestOptionsProperty(enabled=True))
+      # {/fact}

--- a/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_non-compliant.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-open-search-encrypted-at-rest@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_elasticsearch import CfnDomain as LegacyCfnDomain
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+      super(scope, id)
+
+      # Noncompliant: `encryption_at_rest_options` is not set.
+      LegacyCfnDomain(self, 'Domain')
+      # {/fact}

--- a/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-open-search-encrypted-at-rest/python-cdk-open-search-encrypted-at-rest_non-compliant.py
@@ -9,6 +9,6 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
       super(scope, id)
 
-      # Noncompliant: `encryption_at_rest_options` is not set.
+      # Noncompliant: The LegacyCfnDomain instantiation does not set the `encryption_at_rest_options` property, potentially leaving data unencrypted at rest.
       LegacyCfnDomain(self, 'Domain')
       # {/fact}

--- a/python_cdk/src/detectors/python-cdk-publicly-accessible-redshift-cluster/python-cdk-publicly-accessible-redshift-cluster_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-publicly-accessible-redshift-cluster/python-cdk-publicly-accessible-redshift-cluster_compliant.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-publicly-accessible-redshift-cluster@v1.0 defects=0}
+from aws_cdk.aws_redshift import CfnCluster
+from aws_cdk import aws_redshift as redshift
+import aws_cdk as cdk
+
+class CdkStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Compliant: `publicly_accessible` is set to default.
+        CfnCluster(self, "rRedshiftCluster",
+            master_username="awsuser",
+            master_user_password="use_a_secret_here",
+            cluster_type="single-node",
+            db_name="bar", 
+            node_type="ds2.xlarge"  
+        )
+        # {/fact}
+
+      

--- a/python_cdk/src/detectors/python-cdk-publicly-accessible-redshift-cluster/python-cdk-publicly-accessible-redshift-cluster_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-publicly-accessible-redshift-cluster/python-cdk-publicly-accessible-redshift-cluster_non-compliant.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-publicly-accessible-redshift-cluster@v1.0 defects=1}
+from aws_cdk.aws_redshift import CfnCluster
+from aws_cdk import aws_redshift as redshift
+import aws_cdk as cdk
+
+class CdkStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Noncompliant: `publicly_accessible` is set to `True`.
+        redshift.CfnCluster(self, "rRedshiftCluster",
+            master_username="awsuser",
+            master_user_password="use_a_secret_here",  
+            cluster_type="single-node",
+            db_name="bar",
+            node_type="ds2.xlarge",
+            publicly_accessible=True
+        )
+        

--- a/python_cdk/src/detectors/python-cdk-quicksight-ssl-connections/python-cdk-quicksight-ssl-connections_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-quicksight-ssl-connections/python-cdk-quicksight-ssl-connections_compliant.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-quicksight-ssl-connections@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_quicksight import CfnDataSource
+from aws_cdk.aws_quicksight.CfnDataSource import SslPropertiesProperty 
+
+
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)   
+        # Compliant: `disable_ssl` is set to `False`.
+        CfnDataSource(Stack, 'rDashboard', 
+            ssl_properties= SslPropertiesProperty(
+        disable_ssl=False),
+        )
+
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-quicksight-ssl-connections/python-cdk-quicksight-ssl-connections_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-quicksight-ssl-connections/python-cdk-quicksight-ssl-connections_non-compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-quicksight-ssl-connections@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_quicksight import CfnDataSource
+from aws_cdk.aws_quicksight.CfnDataSource import SslPropertiesProperty
+from aws_cdk import aws_quicksight as quicksight 
+
+
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)   
+        # Noncompliant: `disable_ssl` is set to `True`.
+        CfnDataSource(Stack, 'rDashboard', 
+            ssl_properties= SslPropertiesProperty(
+        disable_ssl=True),
+        )
+        # {/fact} 
+       

--- a/python_cdk/src/detectors/python-cdk-rds-instance-backup-enabled/python-cdk-rds-instance-backup-enabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-rds-instance-backup-enabled/python-cdk-rds-instance-backup-enabled_compliant.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-rds-instance-backup-enabled@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_rds import CfnDBInstance
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id) 
+        # Compliant: `backup_retention_period` is set to default.
+        CfnDBInstance(self, 'rDbInstance', 
+            db_instance_class= 'db.t3.micro',
+        )
+        #{/fact}

--- a/python_cdk/src/detectors/python-cdk-rds-instance-backup-enabled/python-cdk-rds-instance-backup-enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-rds-instance-backup-enabled/python-cdk-rds-instance-backup-enabled_non-compliant.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-rds-instance-backup-enabled@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_rds import CfnDBInstance
+from aws_cdk import aws_rds as rds 
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id) 
+
+        # Noncompliant: `backup_retention_period` is set to 0.
+        CfnDBInstance(self, 'rDbInstance', 
+            db_instance_class= 'db.t3.micro',
+            backup_retention_period= 0,
+        )
+        #{/fact}
+
+       

--- a/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_compliant.py
@@ -10,7 +10,7 @@ class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
     
-    # Compliant: Default port is set.
+    # Compliant: The DatabaseCluster instantiation sets a custom port value of 42, overriding the default port.
     DatabaseCluster(self, 'rDbCluster', 
 	    engine=DatabaseClusterEngine.aurora_mysql(version=rds.AuroraMysqlEngineVersion.VER_3_01_0),
 	    port= 42,

--- a/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_compliant.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-rds-non-default-port@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_rds import DatabaseCluster, DatabaseClusterEngine
+from aws_cdk import aws_rds as rds
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+    
+    # Compliant: Default port is set.
+    DatabaseCluster(self, 'rDbCluster', 
+	    engine=DatabaseClusterEngine.aurora_mysql(version=rds.AuroraMysqlEngineVersion.VER_3_01_0),
+	    port= 42,
+	  )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_non-compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-rds-non-default-port@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_rds import AuroraMysqlEngineVersion, DatabaseCluster
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Noncompliant: Default port is not set.
+    DatabaseCluster(self, 'rDbCluster', 
+	    engine=rds.DatabaseClusterEngine.aurora_mysql(version=AuroraMysqlEngineVersion.VER_3_01_0),
+	  )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-rds-non-default-port/python-cdk-rds-non-default-port_non-compliant.py
@@ -9,7 +9,7 @@ class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
 
-    # Noncompliant: Default port is not set.
+    # Noncompliant: The DatabaseCluster instantiation does not set a custom port value, using the default port instead.
     DatabaseCluster(self, 'rDbCluster', 
 	    engine=rds.DatabaseClusterEngine.aurora_mysql(version=AuroraMysqlEngineVersion.VER_3_01_0),
 	  )

--- a/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_compliant.py
@@ -10,7 +10,7 @@ class CdkStarterself(cdk.self):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
         
-        # Compliant: `automated_snapshot_retention_period` is set.
+        # Compliant: The CfnCluster instantiation sets the automated_snapshot_retention_period property to 15 days, enabling automated snapshots retention.
         redshift.CfnCluster(Stack, 'rRedshiftCluster', 
             master_username= 'use_a_secret_here',
             master_user_password= 'use_a_secret_here',

--- a/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_compliant.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-redshift-backup-enabled@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import aws_redshift as redshift 
+from aws_cdk import Stack 
+
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+        
+        # Compliant: `automated_snapshot_retention_period` is set.
+        redshift.CfnCluster(Stack, 'rRedshiftCluster', 
+            master_username= 'use_a_secret_here',
+            master_user_password= 'use_a_secret_here',
+            cluster_type= 'single-node',
+            db_name= 'bar',
+            node_type= 'ds2.xlarge',
+            automated_snapshot_retention_period= 15,
+            encrypted= True,
+            port=42,
+        )
+        # {/fact }

--- a/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_non-compliant.py
@@ -10,7 +10,7 @@ class CdkStarterself(cdk.self):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
      
-        # Noncompliant: `automated_snapshot_retention_period` is set to 0
+        # Noncompliant: The CfnCluster instantiation sets the automated_snapshot_retention_period property to 0, disabling automated snapshots retention.
         CfnCluster(Stack, 'rRedshiftCluster', 
             master_username= 'use_a_secret_here',
             master_user_password= 'use_a_secret_here',

--- a/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_non-compliant.py
@@ -10,7 +10,7 @@ class CdkStarterself(cdk.self):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
      
-        # Noncompliant: `automated_snapshot_retention_period` is not set.
+        # Noncompliant: `automated_snapshot_retention_period` is set to 0
         CfnCluster(Stack, 'rRedshiftCluster', 
             master_username= 'use_a_secret_here',
             master_user_password= 'use_a_secret_here',

--- a/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-redshift-backup-enabled/python-cdk-redshift-backup-enabled_non-compliant.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-redshift-backup-enabled@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_redshift import CfnCluster
+from aws_cdk import  Stack 
+
+class CdkStarterself(cdk.self):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+     
+        # Noncompliant: `automated_snapshot_retention_period` is not set.
+        CfnCluster(Stack, 'rRedshiftCluster', 
+            master_username= 'use_a_secret_here',
+            master_user_password= 'use_a_secret_here',
+            cluster_type= 'single-node',
+            db_name= 'bar',
+            node_type= 'ds2.xlarge',
+            automated_snapshot_retention_period= 0,
+            encrypted= True,
+            port=42,
+        )
+        # {/fact }

--- a/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_compliant.py
@@ -9,7 +9,7 @@ class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
 
-    # Compliant: `server_access_logs_bucket` is set.
+    # Compliant: The Bucket instantiation sets the server_access_logs_bucket property, enabling server access logging to the specified bucket.
     Bucket(self, "LogsBucket", bucket_name="bar")
     Bucket(self, "Bucket", 
         server_access_logs_bucket=Bucket.from_bucket_name(

--- a/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_compliant.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-s3-server-access-logs-disabled@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_s3 import Bucket
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Compliant: `server_access_logs_bucket` is set.
+    Bucket(self, "LogsBucket", bucket_name="bar")
+    Bucket(self, "Bucket", 
+        server_access_logs_bucket=Bucket.from_bucket_name(
+            self, "LogsBucketFromName", "bar"
+        )
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_non-compliant.py
@@ -10,6 +10,6 @@ class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
 
-    # Noncompliant: `server_access_logs_bucket` is not set.
+    # Noncompliant: The Bucket instantiation does not set the `server_access_logs_bucket` property, disabling server access logging.
     Bucket(self, "Bucket") 
     # {/fact}

--- a/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-s3-server-access-logs-disabled/python-cdk-s3-server-access-logs-disabled_non-compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-s3-server-access-logs-disabled@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import aws_s3 as s3
+from aws_cdk.aws_s3 import Bucket
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Noncompliant: `server_access_logs_bucket` is not set.
+    Bucket(self, "Bucket") 
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_compliant.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-sagemaker-notebook-missing-encryption@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk.aws_iam import Role, ServicePrincipal
+from aws_cdk.aws_sagemaker import CfnNotebookInstance
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+
+    # Compliant: `kms_key_id` is set.
+    CfnNotebookInstance(self, "rNotebook",
+        instance_type="ml.t3.xlarge",
+        role_arn=Role(self, "rNotebookRole",
+            assumed_by=ServicePrincipal("sagemaker.amazonaws.com")
+        ).role_arn,
+        kms_key_id="1234abcd-12ab-34cd-56ef-1234567890ab"
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_compliant.py
@@ -10,7 +10,7 @@ class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
 
-    # Compliant: `kms_key_id` is set.
+    # Compliant: The CfnNotebookInstance instantiation sets the `kms_key_id` property, enabling encryption with the specified KMS key.
     CfnNotebookInstance(self, "rNotebook",
         instance_type="ml.t3.xlarge",
         role_arn=Role(self, "rNotebookRole",

--- a/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_non-compliant.py
@@ -9,7 +9,7 @@ from aws_cdk.aws_sagemaker import CfnNotebookInstance
 class CdkStarterself(cdk.self):
   def __init__(self, scope: cdk.App, id: str):
     super(scope, id)
-    # Noncompliant: `kms_key_id` is not set
+    # Noncompliant: The CfnNotebookInstance instantiation does not set the `kms_key_id` property, potentially leaving data unencrypted.
     CfnNotebookInstance(self, "rNotebook",
         instance_type="ml.t3.xlarge",
         role_arn=Role(self, "rNotebookRole", 

--- a/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sagemaker-notebook-missing-encryption/python-cdk-sagemaker-notebook-missing-encryption_non-compliant.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-sagemaker-notebook-missing-encryption@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk.aws_iam import Role, ServicePrincipal
+from aws_cdk.aws_sagemaker import CfnNotebookInstance
+
+class CdkStarterself(cdk.self):
+  def __init__(self, scope: cdk.App, id: str):
+    super(scope, id)
+    # Noncompliant: `kms_key_id` is not set
+    CfnNotebookInstance(self, "rNotebook",
+        instance_type="ml.t3.xlarge",
+        role_arn=Role(self, "rNotebookRole", 
+            assumed_by=ServicePrincipal("sagemaker.amazonaws.com")
+        ).role_arn
+    )
+    # {/fact}

--- a/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_compliant.py
@@ -9,7 +9,7 @@ from aws_cdk import aws_sqs as sqs
 class Stack(cdk.Stack):
 
     def missing_encryption_compliant(self):
-        # Compliant: encryption present.
+        # Compliant: Encryption present.
         encrypted_queue = sqs.Queue(self, 'encrypted_queue',
                                     encryption=sqs.QueueEncryption.KMS_MANAGED)
 # {/fact}

--- a/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-sqs-missing-encryption@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import aws_sqs as sqs
+
+
+class Stack(cdk.Stack):
+
+    def missing_encryption_compliant(self):
+        # Compliant: encryption present.
+        encrypted_queue = sqs.Queue(self, 'encrypted_queue',
+                                    encryption=sqs.QueueEncryption.KMS_MANAGED)
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_compliant.py
@@ -9,7 +9,7 @@ from aws_cdk import aws_sqs as sqs
 class Stack(cdk.Stack):
 
     def missing_encryption_compliant(self):
-        # Compliant: Encryption present.
+        # Compliant: Enabling encryption using an AWS-managed KMS key.
         encrypted_queue = sqs.Queue(self, 'encrypted_queue',
                                     encryption=sqs.QueueEncryption.KMS_MANAGED)
 # {/fact}

--- a/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_non-compliant.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-sqs-missing-encryption@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import aws_sqs as sqs
+
+
+class Stack(cdk.Stack):
+
+    def missing_encryption_noncompliant(self):
+        # Noncompliant: missing encryption.
+        unencrypted_queue = sqs.Queue(self, 'unencrypted_queue')
+# {/fact}

--- a/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_non-compliant.py
@@ -9,6 +9,6 @@ from aws_cdk import aws_sqs as sqs
 class Stack(cdk.Stack):
 
     def missing_encryption_noncompliant(self):
-        # Noncompliant: missing encryption.
+        # Noncompliant: Missing encryption.
         unencrypted_queue = sqs.Queue(self, 'unencrypted_queue')
 # {/fact}

--- a/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python-cdk-sqs-missing-encryption/python-cdk-sqs-missing-encryption_non-compliant.py
@@ -9,6 +9,6 @@ from aws_cdk import aws_sqs as sqs
 class Stack(cdk.Stack):
 
     def missing_encryption_noncompliant(self):
-        # Noncompliant: Missing encryption.
+        # Noncompliant: The Queue instantiation does not set the encryption property, leaving the queue unencrypted.
         unencrypted_queue = sqs.Queue(self, 'unencrypted_queue')
 # {/fact}

--- a/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-apigw-execution-logging-enabled@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_apigateway import RestApi, MethodLoggingLevel, StageOptions
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Compliant: `logging_level` is present.
+        RestApi(Stack, 'rRestApi', deploy_options= StageOptions( logging_level= MethodLoggingLevel.ERROR)).root.add_method('ANY')
+# {/fact}

--- a/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_compliant.py
@@ -10,6 +10,6 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
 
-        # Compliant: `logging_level` is present.
+        # Compliant: The RestApi instantiation has the `logging_level` property set, enabling logging for the API.
         RestApi(Stack, 'rRestApi', deploy_options= StageOptions( logging_level= MethodLoggingLevel.ERROR)).root.add_method('ANY')
 # {/fact}

--- a/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_non-compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-apigw-execution-logging-enabled@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_apigateway import RestApi
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+        # Noncompliant: `logging_level` is not present.
+        RestApi(Stack, 'rRestApi').root.add_method('ANY')
+    # {/fact}

--- a/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_apigw_execution_logging_enabled/python_cdk_apigw_execution_logging_enabled_non-compliant.py
@@ -10,6 +10,6 @@ class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
 
-        # Noncompliant: `logging_level` is not present.
+        # Noncompliant: The RestApi instantiation does not set the `logging_level` property, disabling logging for the API.
         RestApi(Stack, 'rRestApi').root.add_method('ANY')
     # {/fact}

--- a/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_compliant.py
@@ -7,7 +7,7 @@ from aws_cdk import Stack
 
 class AthenaIncompleteEncryption:    
     def __init__(self):
-        # Compliant: `work_group_configuration` is set. 
+       # Compliant: The CfnWorkGroup instantiation sets the `work_group_configuration` property, including encryption configuration for results using SSE-S3.
         CfnWorkGroup(Stack, 'rWorkgroup', name='foo',
             work_group_configuration=CfnWorkGroup.WorkGroupConfigurationProperty(
                 enforce_work_group_configuration=True,

--- a/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_compliant.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-athena-incomplete-encryption@v1.0 defects=0}
+from aws_cdk.aws_athena import CfnWorkGroup
+from aws_cdk import Stack
+
+class AthenaIncompleteEncryption:    
+    def __init__(self):
+        # Compliant: `work_group_configuration` is set. 
+        CfnWorkGroup(Stack, 'rWorkgroup', name='foo',
+            work_group_configuration=CfnWorkGroup.WorkGroupConfigurationProperty(
+                enforce_work_group_configuration=True,
+                result_configuration=CfnWorkGroup.ResultConfigurationProperty(
+                    encryption_configuration=CfnWorkGroup.EncryptionConfigurationProperty(
+                        encryption_option='SSE_S3',
+                    )
+                )
+            )
+        )
+    # {/fact}

--- a/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_non-compliant.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-athena-incomplete-encryption@v1.0 defects=1}
+from aws_cdk.aws_athena import CfnWorkGroup
+from aws_cdk import Stack
+import aws_cdk
+
+class AthenaIncompleteEncryption:    
+    def __init__(self):
+
+        # Noncompliant: `work_group_configuration` is not set. 
+        CfnWorkGroup(Stack, 'rWorkgroup', name='foo')
+# {/fact}

--- a/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_athena_incomplete_encryption/python_cdk_athena_incomplete_encryption_non-compliant.py
@@ -9,6 +9,6 @@ import aws_cdk
 class AthenaIncompleteEncryption:    
     def __init__(self):
 
-        # Noncompliant: `work_group_configuration` is not set. 
+        # Noncompliant: The CfnWorkGroup instantiation does not set the `work_group_configuration` property, potentially leaving results unencrypted.
         CfnWorkGroup(Stack, 'rWorkgroup', name='foo')
 # {/fact}

--- a/python_cdk/src/detectors/python_cdk_cognito_user_pool_no_unauthenticated_logins/python_cdk_cognito_user_pool_no_unauthenticated_logins_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_cognito_user_pool_no_unauthenticated_logins/python_cdk_cognito_user_pool_no_unauthenticated_logins_compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-cognito-user-pool-no-unauthenticated-logins@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_cognito import CfnIdentityPool
+import aws_cdk.aws_cognito as cognito
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+    # Compliant: `allow_unauthenticated_identities` is set to `False`.
+    CfnIdentityPool(Stack, 'rIdentityPool', allow_unauthenticated_identities=False)
+    # {/fact}

--- a/python_cdk/src/detectors/python_cdk_cognito_user_pool_no_unauthenticated_logins/python_cdk_cognito_user_pool_no_unauthenticated_logins_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_cognito_user_pool_no_unauthenticated_logins/python_cdk_cognito_user_pool_no_unauthenticated_logins_non-compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-cognito-user-pool-no-unauthenticated-logins@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_cognito import CfnIdentityPool
+import aws_cdk.aws_cognito as cognito
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+
+    # Noncompliant: `allow_unauthenticated_identities` is set to `True`.
+    CfnIdentityPool(Stack, 'rIdentityPool', allow_unauthenticated_identities=True)
+    # {/fact}

--- a/python_cdk/src/detectors/python_cdk_ecs_cluster_cloud_watch_container_insights/python_cdk_ecs_cluster_cloud_watch_container_insights_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_ecs_cluster_cloud_watch_container_insights/python_cdk_ecs_cluster_cloud_watch_container_insights_compliant.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-ecs-cluster-cloud-watch-container-insights@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_ecs import Cluster
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+        # Compliant: `container_insights` is set to `True`.
+        Cluster(Stack, 'rCluster', container_insights= True )
+    # {/fact}

--- a/python_cdk/src/detectors/python_cdk_ecs_cluster_cloud_watch_container_insights/python_cdk_ecs_cluster_cloud_watch_container_insights_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_ecs_cluster_cloud_watch_container_insights/python_cdk_ecs_cluster_cloud_watch_container_insights_non-compliant.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-ecs-cluster-cloud-watch-container-insights@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_ecs import Cluster
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+        # Noncompliant: `container_insights` is set to `False`.
+        Cluster(Stack, 'rCluster', container_insights= False)
+	    # {/fact}

--- a/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_compliant.py
@@ -8,11 +8,11 @@ from aws_cdk import Stack
 
 
 class CdkStarterStack(cdk.Stack):
-        def __init__(self, scope: cdk.App, id: str):
-                super(scope, id)        
-                
-                # Compliant: `enable_key_rotation` is set.
-                Key(Stack, 'rSymmetricKey', enable_key_rotation= True )
-                #{/fact}
+     def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)        
+        
+        # Compliant: `enable_key_rotation` is set.
+        Key(Stack, 'rSymmetricKey', enable_key_rotation= True )
+        #{/fact}
 
                

--- a/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_compliant.py
@@ -11,7 +11,7 @@ class CdkStarterStack(cdk.Stack):
      def __init__(self, scope: cdk.App, id: str):
         super(scope, id)        
         
-        # Compliant: `enable_key_rotation` is set.
+       # Compliant: The Key instantiation sets the `enable_key_rotation` property to True, enabling automatic rotation of the KMS key.
         Key(Stack, 'rSymmetricKey', enable_key_rotation= True )
         #{/fact}
 

--- a/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_compliant.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-kms-backing-key-rotation-enabled@v1.0 defects=0}
+from aws_cdk.aws_kms import Key, KeySpec 
+import aws_cdk as cdk
+from aws_cdk import Stack
+
+
+class CdkStarterStack(cdk.Stack):
+        def __init__(self, scope: cdk.App, id: str):
+                super(scope, id)        
+                
+                # Compliant: `enable_key_rotation` is set.
+                Key(Stack, 'rSymmetricKey', enable_key_rotation= True )
+                #{/fact}
+
+               

--- a/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_non-compliant.py
@@ -9,7 +9,7 @@ from aws_cdk import Stack
 class CdkStarterStack(cdk.Stack):
      def __init__(self, scope: cdk.App, id: str):
         super(scope, id)        
-        # Noncompliant: `enable_key_rotation` is not set.
+       # Noncompliant: The Key instantiation does not set the `enable_key_rotation` property, disabling automatic rotation of the KMS key.
         Key(Stack, 'rSymmetricKey')
         #{/fact}
                 

--- a/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_non-compliant.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-kms-backing-key-rotation-enabled@v1.0 defects=1}
+from aws_cdk.aws_kms import Key, KeySpec 
+import aws_cdk as cdk
+from aws_cdk import Stack
+
+class CdkStarterStack(cdk.Stack):
+        def __init__(self, scope: cdk.App, id: str):
+                super(scope, id)        
+                # Noncompliant: `enable_key_rotation` is not set.
+                Key(Stack, 'rSymmetricKey')
+                #{/fact}
+                

--- a/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_kms_backing_key_rotation_enabled/python_cdk_kms_backing_key_rotation_enabled_non-compliant.py
@@ -7,9 +7,9 @@ import aws_cdk as cdk
 from aws_cdk import Stack
 
 class CdkStarterStack(cdk.Stack):
-        def __init__(self, scope: cdk.App, id: str):
-                super(scope, id)        
-                # Noncompliant: `enable_key_rotation` is not set.
-                Key(Stack, 'rSymmetricKey')
-                #{/fact}
+     def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)        
+        # Noncompliant: `enable_key_rotation` is not set.
+        Key(Stack, 'rSymmetricKey')
+        #{/fact}
                 

--- a/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_compliant.py
@@ -10,7 +10,7 @@ from aws_cdk.aws_neptune import CfnDBCluster
 class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
-        # Compliant: `iam_auth_enabled` is set.
+        # Compliant: The CfnDBCluster instantiation sets the `iam_auth_enabled` property to True, enabling IAM authentication for the database cluster.
         CfnDBCluster(Stack, "rDatabaseCluster", iam_auth_enabled=True)
 
 # {/fact}

--- a/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-neptunedb-database-authentication-disabled@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_neptune import CfnDBCluster
+
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+        # Compliant: `iam_auth_enabled` is set.
+        CfnDBCluster(Stack, "rDatabaseCluster", iam_auth_enabled=True)
+
+# {/fact}

--- a/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_non-compliant.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-neptunedb-database-authentication-disabled@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk.aws_neptune import CfnDBCluster
+
+
+class CdkStarterStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str):
+        super(scope, id)
+        # Noncompliant: `iam_auth_enabled` is not set.
+        CfnDBCluster(Stack, "rDatabaseCluster")
+
+
+# {/fact}

--- a/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_neptunedb_database_authentication_disabled/python_cdk_neptunedb_database_authentication_disabled_non-compliant.py
@@ -10,7 +10,7 @@ from aws_cdk.aws_neptune import CfnDBCluster
 class CdkStarterStack(cdk.Stack):
     def __init__(self, scope: cdk.App, id: str):
         super(scope, id)
-        # Noncompliant: `iam_auth_enabled` is not set.
+        # Noncompliant: The CfnDBCluster instantiation does not sets the `iam_auth_enabled` property.
         CfnDBCluster(Stack, "rDatabaseCluster")
 
 

--- a/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-open-search-missing-node-to-node-encryption@v1.0 defects=0}
+import aws_cdk
+from aws_cdk.aws_elastic_search import CfnDomain as LegacyCfnDomain
+from aws_cdk.aws_opensearchservice import CfnDomain
+from aws_cdk import Stack
+
+class CdkStarterStack(aws_cdk.Stack):
+    def __init__(self):
+    
+        # Compliant: `node_to_node_encryption_options` is set.
+        LegacyCfnDomain(Stack, 'Domain',
+            node_to_node_encryption_options=CfnDomain.NodeToNodeEncryptionOptionsProperty(
+                enabled=True
+            )
+        )
+
+# {/fact}

--- a/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_compliant.py
@@ -9,8 +9,8 @@ from aws_cdk import Stack
 
 class CdkStarterStack(aws_cdk.Stack):
     def __init__(self):
-    
-        # Compliant: `node_to_node_encryption_options` is set.
+
+        # Compliant: The LegacyCfnDomain instantiation sets the `node_to_node_encryption_options` property with NodeToNodeEncryptionOptionsProperty,enabling encryption at rest.
         LegacyCfnDomain(Stack, 'Domain',
             node_to_node_encryption_options=CfnDomain.NodeToNodeEncryptionOptionsProperty(
                 enabled=True

--- a/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_non-compliant.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-open-search-missing-node-to-node-encryption@v1.0 defects=1}
+import aws_cdk
+from aws_cdk.aws_elastic_search import CfnDomain as LegacyCfnDomain
+from aws_cdk.aws_opensearchservice import CfnDomain
+from aws_cdk import Stack
+
+class CdkStarterStack(aws_cdk.Stack):
+    def __init__(self):
+        # Noncompliant: `node_to_node_encryption_options` is not set.
+        LegacyCfnDomain(Stack, 'Domain')
+
+       
+# {/fact}

--- a/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_non-compliant.py
@@ -9,8 +9,8 @@ from aws_cdk import Stack
 
 class CdkStarterStack(aws_cdk.Stack):
     def __init__(self):
-        # Noncompliant: `node_to_node_encryption_options` is not set.
-        LegacyCfnDomain(Stack, 'Domain')
+        # Noncompliant: The LegacyCfnDomain instantiation does not set the `encryption_at_rest_options` property, potentially leaving data unencrypted at rest.
+        # Noncompliant: The LegacyCfnDomain instantiation does not set the `node_to_node_encryption_options` property, potentially leaving data unencrypted at rest.
 
        
 # {/fact}

--- a/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_open_search_missing_node_to_node_encryption/python_cdk_open_search_missing_node_to_node_encryption_non-compliant.py
@@ -9,8 +9,9 @@ from aws_cdk import Stack
 
 class CdkStarterStack(aws_cdk.Stack):
     def __init__(self):
-        # Noncompliant: The LegacyCfnDomain instantiation does not set the `encryption_at_rest_options` property, potentially leaving data unencrypted at rest.
-        # Noncompliant: The LegacyCfnDomain instantiation does not set the `node_to_node_encryption_options` property, potentially leaving data unencrypted at rest.
+        
+        # Noncompliant: The LegacyCfnDomain instantiation does not set the `node_to_node_encryption_options` is not set.
+        LegacyCfnDomain(Stack, 'Domain')
 
        
 # {/fact}

--- a/python_cdk/src/detectors/python_cdk_step_function_logs_partial_events/python_cdk_step_function_logs_partial_events_compliant.py
+++ b/python_cdk/src/detectors/python_cdk_step_function_logs_partial_events/python_cdk_step_function_logs_partial_events_compliant.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-step-function-logs-partial-events@v1.0 defects=0}
+from aws_cdk import Stack
+from aws_cdk.aws_stepfunctions import StateMachine
+import aws_cdk as cdk
+
+
+class StepFunctionLog:
+    
+    def __init__(self):
+        super(scope, id, props)
+
+        # Compliant: logs enabled with `LogLevel.ALL`.
+        StateMachine(Stack, 'rStateMachine', logs=sfn.LogOptions(
+            destination=log_group,
+            level=sfn.LogLevel.ALL
+        ))
+        # {/fact}

--- a/python_cdk/src/detectors/python_cdk_step_function_logs_partial_events/python_cdk_step_function_logs_partial_events_non-compliant.py
+++ b/python_cdk/src/detectors/python_cdk_step_function_logs_partial_events/python_cdk_step_function_logs_partial_events_non-compliant.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# {fact rule=python-cdk-step-function-logs-partial-events@v1.0 defects=1}
+from aws_cdk import Stack
+
+from aws_cdk.aws_stepfunctions import StateMachine
+from aws_cdk.aws_stepfunctions import LogOptions
+import aws_cdk as cdk
+
+
+class StepFunctionLog:
+    
+    def __init__(self):
+        super(scope, id, props)
+        # Compliant: logs not enabled with `LogLevel.ALL`.
+        StateMachine(Stack, 'rStateMachine')
+       # {/fact}


### PR DESCRIPTION
Add non compliant and compliant samples for python_cdk detectors.

Note: All the test cases have 100% recall and precision.