### PR TITLE
Added compliant and noncompliant DL case for typescript_cdk

### DIFF
--- a/cdk_typescript/src/detectors/typescript-cdk-api-logging-disabled/typescript-cdk-api-logging-disabled_complitant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-api-logging-disabled/typescript-cdk-api-logging-disabled_complitant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-api-logging-disabled@v1.0 defects=0}
+import * as cdk from "@aws-cdk/core"
+import { CfnStage as CfnV2Stage } from "aws-cdk-lib/aws-apigatewayv2"
+import { Stack } from "aws-cdk-lib/core"
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: Logging enabled.
+		new CfnV2Stage(Stack, "rStage", {
+			accessLogSettings: {
+				destinationArn: "foo",
+				format: "$context.requestId"
+			},
+			apiId: "bar",
+			stageName: "baz"
+		})
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-api-logging-disabled/typescript-cdk-api-logging-disabled_non-complitant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-api-logging-disabled/typescript-cdk-api-logging-disabled_non-complitant.ts
@@ -1,0 +1,23 @@
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-api-logging-disabled@v1.0 defects=1}
+import * as cdk from "@aws-cdk/core"
+import { CfnStage as CfnV2Stage } from "aws-cdk-lib/aws-apigatewayv2"
+import { Stack } from "aws-cdk-lib/core"
+
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props)
+
+        // Noncompliant: Logging disabled.
+        new CfnV2Stage(Stack, "rHttpApiDefaultStage", {
+            apiId: "foo",
+            stageName: "baz"
+        })
+
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-backtrack/typescript-cdk-aurora-my-sql-backtrack_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-backtrack/typescript-cdk-aurora-my-sql-backtrack_compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-aurora-my-backtrack@v1.0 defects=0}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+} from 'aws-cdk-lib/aws-rds';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);    
+        
+		// Compliant: The DatabaseCluster sets `backtrackWindow` to a suitable value.
+		new DatabaseCluster(Stack, 'rDbCluster', {
+			engine: DatabaseClusterEngine.auroraMysql({
+			version: AuroraMysqlEngineVersion.VER_5_7_12,
+			}),
+			backtrackWindow: 30,
+			instanceProps: { vpc: new Vpc(Stack, 'rVpc') },
+		});
+  	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-backtrack/typescript-cdk-aurora-my-sql-backtrack_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-backtrack/typescript-cdk-aurora-my-sql-backtrack_non-compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-aurora-my-backtrack@v1.0 defects=1}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+} from 'aws-cdk-lib/aws-rds';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);    
+        
+        // Noncompliant: `backtrackWindow` is not set for DatabaseCluster.
+        new DatabaseCluster(Stack, 'rDbCluster', {
+            engine: DatabaseClusterEngine.auroraMysql({
+            version: AuroraMysqlEngineVersion.VER_5_7_12,
+            }),
+            instanceProps: { vpc: new Vpc(Stack, 'rVpc') },
+        });
+    }
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aws-dynamodb-billing-mode/typescript-cdk-aws-dynamodb-billing-mode_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aws-dynamodb-billing-mode/typescript-cdk-aws-dynamodb-billing-mode_compliant.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-aws-dynamodb-billing-mode@v1.0 defects=0}
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Stack } from 'aws-cdk-lib/core';
+
+// Compliant: The table instantiation sets `billingMode` to `BillingMode.PAY_PER_REQUEST`, allowing flexible capacity management.
+new Table(Stack, 'MyTable', {
+    partitionKey: { name: 'foo', type: AttributeType.STRING },
+    billingMode: BillingMode.PAY_PER_REQUEST
+});
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aws-dynamodb-billing-mode/typescript-cdk-aws-dynamodb-billing-mode_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aws-dynamodb-billing-mode/typescript-cdk-aws-dynamodb-billing-mode_non-compliant.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-aws-dynamodb-billing-mode@v1.0 defects=1}
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Stack } from 'aws-cdk-lib/core';
+
+// Noncompliant: `billingMode` is not set.
+new Table(Stack, 'rTable', {
+	partitionKey: { name: 'foo', type: AttributeType.STRING },
+});
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced_compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cognito-user-pool-advanced-security-mode-enforced@v1.0 defects=0}
+import {
+    CfnUserPool,
+} from 'aws-cdk-lib/aws-cognito';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        // Compliant: `advancedSecurityMode` set to ENFORCED.
+        new CfnUserPool(Stack, 'rUserPool', {
+            userPoolAddOns: { advancedSecurityMode: 'ENFORCED' },
+        });
+
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced/typescript-cdk-cognito-user-pool-advanced-security-mode-enforced_non-compliant.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+// {fact rule=typescript-cdk-cognito-user-pool-advanced-security-mode-enforced@v1.0 defects=1}
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        // Noncompliant: `advancedSecurityMode` not set to ENFORCED.
+        new UserPool(Stack, 'rUserPool');
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-no-unauthenticated-logins/typescript-cdk-cognito-user-pool-no-unauthenticated-logins_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-no-unauthenticated-logins/typescript-cdk-cognito-user-pool-no-unauthenticated-logins_compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cognito-user-pool-no-unauthenticated-logins@v1.0defects=0}
+import {
+    CfnIdentityPool
+} from 'aws-cdk-lib/aws-cognito';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        // Compliant: The CfnIdentityPool instantiation sets `allowUnauthenticatedIdentities` to `false`, avoiding potential security risk.
+        new CfnIdentityPool(Stack, 'rIdentityPool', {
+            allowUnauthenticatedIdentities: false,
+        });
+    }
+}
+
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-no-unauthenticated-logins/typescript-cdk-cognito-user-pool-no-unauthenticated-logins_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-no-unauthenticated-logins/typescript-cdk-cognito-user-pool-no-unauthenticated-logins_non-compliant.ts
@@ -1,0 +1,23 @@
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cognito-user-pool-no-unauthenticated-logins@v1.0 defects=1}
+import {
+    CfnIdentityPool
+} from 'aws-cdk-lib/aws-cognito';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        // Noncompliant: The CfnIdentityPool instantiation doesn't set `allowUnauthenticatedIdentities` to `false`, avoiding potential security risk.
+        new CfnIdentityPool(Stack, 'rIdentityPool', {
+            allowUnauthenticatedIdentities: true,
+        });
+        
+    }
+}
+
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-log-exports/typescript-cdk-document-db-cluster-log-exports_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-log-exports/typescript-cdk-document-db-cluster-log-exports_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-log-exports@v1.0 defects=0}
+import { CfnDBCluster } from 'aws-cdk-lib/aws-docdb';
+import { SecretValue, Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    
+		// Compliant: The CfnDBCluster instantiation sets `enableCloudwatchLogsExports`, enabling authenticate, createIndex, and dropCollection Log Exports.
+		new CfnDBCluster(Stack, 'rDatabaseCluster', {
+			masterUsername: SecretValue.secretsManager('foo').toString(),
+			masterUserPassword: SecretValue.secretsManager('bar').toString(),
+			enableCloudwatchLogsExports: [
+				'authenticate',
+				'createIndex',
+				'dropCollection',
+			],
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-log-exports/typescript-cdk-document-db-cluster-log-exports_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-log-exports/typescript-cdk-document-db-cluster-log-exports_non-compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-log-exports@v1.0 defects=1}
+import { CfnDBCluster, DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+InstanceType,
+InstanceClass,
+InstanceSize,
+Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+import { Aspects, Duration, SecretValue, Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    
+		// Noncompliant: The DatabaseCluster instantiation does not set `enableCloudwatchLogsExports`.
+		new DatabaseCluster(Stack, 'rDatabaseCluster', {
+			instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+			vpc: new Vpc(Stack, 'rVpc'),
+			masterUser: {
+				username: SecretValue.secretsManager('foo').toString(),
+				password: SecretValue.secretsManager('bar'),
+			},
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec2-expose-selective-ports/typescript-cdk-ec2-expose-selective-ports_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec2-expose-selective-ports/typescript-cdk-ec2-expose-selective-ports_compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec2-expose-selective-ports@v1.0 defects=0}
+import * as cdk from '@aws-cdk/core'
+import { CfnSecurityGroupIngress, } from 'aws-cdk-lib/aws-ec2'
+import {Stack} from 'aws-cdk-lib/core'
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props)
+
+        // Compliant: The CfnSecurityGroupIngress instantiation does not use the `0.0.0.0/0` range.
+        new CfnSecurityGroupIngress(Stack, 'rIngress', {
+            ipProtocol: 'tcp',
+            cidrIp: '1.2.3.4/32',
+        })
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec2-expose-selective-ports/typescript-cdk-ec2-expose-selective-ports_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec2-expose-selective-ports/typescript-cdk-ec2-expose-selective-ports_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec2-expose-selective-ports@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core'
+import { CfnSecurityGroupIngress, } from 'aws-cdk-lib/aws-ec2'
+import {Stack} from 'aws-cdk-lib/core'
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props)
+
+        // Noncompliant: The CfnSecurityGroupIngress instantiation uses the `0.0.0.0/0` range.
+        new CfnSecurityGroupIngress(Stack, 'rIngress', {
+            ipProtocol: 'tcp',
+            cidrIp: '0.0.0.0/0',
+        })
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ecr-open-access/typescript-cdk-ecr-open-access_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ecr-open-access/typescript-cdk-ecr-open-access_compliant.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ecr-open-access@v1.0 defects=0}
+import * as cdk from '@aws-cdk/core'
+import { Stack } from 'aws-cdk-lib/core'
+
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props)
+
+        // Compliant: '*' principals in an ECR Repository is not used.
+        new Repository(Stack, 'rRepo')
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ecr-open-access/typescript-cdk-ecr-open-access_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ecr-open-access/typescript-cdk-ecr-open-access_non-compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ecr-open-access@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core'
+import { Repository } from 'aws-cdk-lib/aws-ecr'
+import { PolicyStatement, Effect, AccountPrincipal, AccountRootPrincipal, } from 'aws-cdk-lib/aws-iam'
+import { Stack } from 'aws-cdk-lib/core'
+
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props)
+
+		const repo = new Repository(Stack, 'rRepo')
+
+		// Noncompliant: '*' principals in an ECR Repository is used.
+		repo.addToResourcePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['*'],
+				principals: [new AccountPrincipal('*'), new AccountRootPrincipal()],
+			})
+		)
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elb-logging-enabled/typescript-cdk-elb-logging-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elb-logging-enabled/typescript-cdk-elb-logging-enabled_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elb-logging-enabled@v1.0 defects=0}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  ApplicationLoadBalancer
+} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib/core';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: Enabled access logging by setting `accessLoggingPolicy` to `true` for Classic Load Balancers.
+		const alb = new ApplicationLoadBalancer(Stack, 'rALB', {
+			vpc: new Vpc(Stack, 'rVPC'),
+		});
+		alb.logAccessLogs(new Bucket(Stack, 'rLogsBucket'));
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elb-logging-enabled/typescript-cdk-elb-logging-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elb-logging-enabled/typescript-cdk-elb-logging-enabled_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elb-logging-enabled@v1.0 defects=1}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {aws_elasticloadbalancing as elb}from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib/core';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: Disabled access logging by setting `accessLoggingPolicy` to `false` for Classic Load Balancers.
+		new elb.LoadBalancer(Stack, 'rELB', {
+			vpc: new Vpc(Stack, 'rVPC'),
+			accessLoggingPolicy: {
+				s3BucketName: 'foo',
+				enabled: false,
+			},
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-kmskey-encryption/typescript-cdk-kmskey-encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-kmskey-encryption/typescript-cdk-kmskey-encryption_compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kmskey-encryption@v1.0 defects=0}
+import { BuildSpec, Project } from "aws-cdk-lib/aws-codebuild";
+import * as cdk from "@aws-cdk/core";
+import { Stack } from "aws-cdk-lib/core";
+import { Key } from "aws-cdk-lib/aws-kms";
+
+  
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        // Compliant: The Project instantiation sets KMS key encryption configuration.
+        new Project(Stack, "rBuildProject", {
+            buildSpec: BuildSpec.fromObjectToYaml(
+                {
+                    version: 0.2,
+                    phases: {
+                        build: { commands: ['echo "foo"'] }
+                    }
+                }),
+            encryptionKey: new Key(Stack, "rBuildKey")
+
+        });
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-kmskey-encryption/typescript-cdk-kmskey-encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-kmskey-encryption/typescript-cdk-kmskey-encryption_non-compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kmskey-encryption@v1.0 defects=1}
+import { BuildSpec, Project } from "aws-cdk-lib/aws-codebuild";
+import * as cdk from "@aws-cdk/core";
+import { Stack } from "aws-cdk-lib/core";
+
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        // Noncompliant: The Project instantiation does not set KMS key encryption configuration.
+        new Project(Stack, "rBuildProject", {
+            buildSpec: BuildSpec.fromObjectToYaml(
+                {
+                    version: 0.2,
+                    phases: {
+                    build: { commands: ['echo "foo"'], } }
+                }
+            )
+        });
+    }
+}
+// {/fact}
+  

--- a/cdk_typescript/src/detectors/typescript-cdk-lambda-latest-version/typescript-cdk-lambda-latest-version_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-lambda-latest-version/typescript-cdk-lambda-latest-version_compliant.ts
@@ -1,0 +1,25 @@
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-lambda-latest-version@v1.0 defects=0}
+import { Stack } from 'aws-cdk-lib';
+import {
+    CfnFunction,
+    Runtime
+} from 'aws-cdk-lib/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        // Compliant: Latest runtime version is used.
+        new CfnFunction(Stack, 'rFunction', {
+            runtime: getLatestRuntime('nodejs').toString(),
+            code: {},
+            role: 'somerole'
+        });
+    }
+}
+
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-lambda-latest-version/typescript-cdk-lambda-latest-version_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-lambda-latest-version/typescript-cdk-lambda-latest-version_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-lambda-latest-version@v1.0 defects=1}
+import { Stack } from 'aws-cdk-lib';
+import {
+    CfnFunction,
+    Runtime
+} from 'aws-cdk-lib/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        // Noncompliant: Latest runtime version is not used.
+        new CfnFunction(Stack, 'rFunction', {
+            runtime: Runtime.NODEJS_16_X.toString(),
+            code: {},
+            role: 'somerole'
+        });
+    }
+}
+
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-in-vpc-only/typescript-cdk-open-search-in-vpc-only_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-in-vpc-only/typescript-cdk-open-search-in-vpc-only_compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-in-vpc-only@v1.0 defects=0}
+import {  CfnDomain as LegacyCfnDomain } from 'aws-cdk-lib/aws-elasticsearch';
+ import * as cdk from 'aws-cdk-lib';
+ import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        // Compliant: The LegacyCfnDomain instantiation sets `subnetIds`.
+        new LegacyCfnDomain(Stack, 'Domain', {
+            vpcOptions: {
+            subnetIds: ['mycoolsubnet'],
+            },
+        });
+    }
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-in-vpc-only/typescript-cdk-open-search-in-vpc-only_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-in-vpc-only/typescript-cdk-open-search-in-vpc-only_non-compliant.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-in-vpc-only@v1.0 defects=1}
+import {  CfnDomain as LegacyCfnDomain } from 'aws-cdk-lib/aws-elasticsearch';
+ import * as cdk from 'aws-cdk-lib';
+ import { Stack } from "aws-cdk-lib/core";
+ 	 
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        //  Noncompliant: `subnetIds` is not set for LegacyCfnDomain instantiation.
+        new LegacyCfnDomain(Stack, 'Domain', {});
+
+    }
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-non-default-port/typescript-cdk-rds-non-default-port_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-non-default-port/typescript-cdk-rds-non-default-port_compliant.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-non-default-port@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib/core';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine
+} from 'aws-cdk-lib/aws-rds';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		// Compliant: The DatabaseCluster instantiation sets a custom port value of 42, overriding the default port.
+		const vpc = new Vpc(Stack, 'rVpc');
+		new DatabaseCluster(Stack, 'rDbCluster', {
+			engine: DatabaseClusterEngine.auroraMysql({
+				version: AuroraMysqlEngineVersion.VER_5_7_12,
+			}),
+			instanceProps: { vpc: vpc },
+			port: 42,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-non-default-port/typescript-cdk-rds-non-default-port_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-non-default-port/typescript-cdk-rds-non-default-port_non-compliant.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-non-default-port@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib/core';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+} from 'aws-cdk-lib/aws-rds';
+
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The DatabaseCluster instantiation does not set a custom port value, using the default port instead.
+		new DatabaseCluster(Stack, 'rDbCluster', {
+			engine: DatabaseClusterEngine.auroraMysql({
+				version: AuroraMysqlEngineVersion.VER_5_7_12,
+			}),
+			instanceProps: { vpc: new Vpc(Stack, 'rVpc') },
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-in-vpc/typescript-cdk-redshift-cluster-in-vpc_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-in-vpc/typescript-cdk-redshift-cluster-in-vpc_compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-in-vpc@v1.0 defects=0}
+import { CfnCluster, CfnClusterProps } from 'aws-cdk-lib/aws-redshift';
+import {Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);    
+		
+		// Compliant: The CfnCluster instantiation sets `clusterSubnetGroupName`.
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: os.environ.get('PASSWORD'),
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+			clusterSubnetGroupName: 'foo',
+			encrypted: true,
+			port:42,
+		});
+		
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-in-vpc/typescript-cdk-redshift-cluster-in-vpc_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-in-vpc/typescript-cdk-redshift-cluster-in-vpc_non-compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-in-vpc@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import {Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);    
+       
+		// Noncompliant: The CfnCluster instantiation does not set `clusterSubnetGroupName`. 
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: os.environ.get('PASSWORD'),
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+			encrypted: true,
+			port:42,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-enable-user-activity-logging/typescript-cdk-redshift-enable-user-activity-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-enable-user-activity-logging/typescript-cdk-redshift-enable-user-activity-logging_compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-enable-user-activity-logging@v1.0 defects=0}
+import { CfnClusterParameterGroup } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: Activity logging is enabled by setting `enable_user_activity_logging` to `true`.
+		const compliantParamGroup2 = new CfnClusterParameterGroup(
+			Stack,
+			'rCfnParameterGroup',
+			{
+			description: 'foo',
+			parameterGroupFamily: 'redshift-1.0',
+			parameters: [
+				{
+				parameterName: 'enable_user_activity_logging',
+				parameterValue: 'true',
+				},
+			],
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-enable-user-activity-logging/typescript-cdk-redshift-enable-user-activity-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-enable-user-activity-logging/typescript-cdk-redshift-enable-user-activity-logging_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-enable-user-activity-logging@v1.0 defects=1}
+import { CfnCluster, CfnClusterParameterGroup } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: Activity logging is disabled by setting `enable_user_activity_logging` to `false`.
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: 'use_a_secret_here',
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sqs-missing-encryption/typescript-cdk-sqs-missing-encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sqs-missing-encryption/typescript-cdk-sqs-missing-encryption_compliant.ts
@@ -1,0 +1,18 @@
+    
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sqs-missing-encryption@v1.0 defects=0}
+import * as cdk from '@aws-cdk/core';
+import * as sqs from '@aws-cdk/aws-sqs';
+
+export class Stack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		// Compliant: Queue is encrypted using `QueueEncryption.KMS_MANAGED`.
+		const encryptedQueue = new sqs.Queue(this, 'encryptedQueue', {
+			encryption: sqs.QueueEncryption.KMS_MANAGED
+		})
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sqs-missing-encryption/typescript-cdk-sqs-missing-encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sqs-missing-encryption/typescript-cdk-sqs-missing-encryption_non-compliant.ts
@@ -1,0 +1,17 @@
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sqs-missing-encryption@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core';
+import * as sqs from '@aws-cdk/aws-sqs';
+
+export class Stack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		// Noncompliant: Queue is not encrypted.
+		const unencryptedQueue = new sqs.Queue(this, 'unecryptedQueue1')
+	
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-step-function-logs-partial-events/typescript-cdk-step-function-logs-partial-events_complaint.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-step-function-logs-partial-events/typescript-cdk-step-function-logs-partial-events_complaint.ts
@@ -1,0 +1,28 @@
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-step-function-logs-partial-events@v1.0 defects=0}
+import * as cdk from '@aws-cdk/core'
+import { LogGroup } from 'aws-cdk-lib/aws-logs'
+import { StateMachine, Wait, WaitTime, LogLevel, } from 'aws-cdk-lib/aws-stepfunctions'
+import { Duration, Stack } from 'aws-cdk-lib/core'
+
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props)
+
+        // Compliant: `ALL` events logs is used.
+        new StateMachine(Stack, 'rStateMachine',{
+            definition: new Wait(Stack, 'rWait30', {
+                time: WaitTime.duration(Duration.seconds(30))
+            }),
+            logs: {
+                level: LogLevel.ALL,
+                destination: new LogGroup(Stack, 'rSfnLog')
+            }
+        });
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-step-function-logs-partial-events/typescript-cdk-step-function-logs-partial-events_non_complaint.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-step-function-logs-partial-events/typescript-cdk-step-function-logs-partial-events_non_complaint.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-step-function-logs-partial-events@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core'
+import { StateMachine, Wait, WaitTime, LogLevel, } from 'aws-cdk-lib/aws-stepfunctions'
+import { Duration, Stack } from 'aws-cdk-lib/core'
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props)
+
+        // Noncompliant: `ALL` events logs is not used.
+        new StateMachine(Stack, 'rStateMachine', {
+            definition: new Wait(Stack, 'rWait30', {
+                time: WaitTime.duration(Duration.seconds(30))
+            })
+        })
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-vpc-flow-logs-enabled/typescript-cdk-vpc-flow-logs-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-vpc-flow-logs-enabled/typescript-cdk-vpc-flow-logs-enabled_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-vpc-flow-logs-enabled@v1.0 defects=0}
+import {
+    FlowLog,
+    FlowLogResourceType,
+    Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const compliantVpc = new Vpc(Stack, 'rVpc1');
+        // Compliant: The FlowLog instantiation sets `resourceType` to `compliantVpc`.
+        new FlowLog(Stack, 'rFlowFlog1', {
+            resourceType: FlowLogResourceType.fromVpc(compliantVpc),
+        });
+    
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-vpc-flow-logs-enabled/typescript-cdk-vpc-flow-logs-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-vpc-flow-logs-enabled/typescript-cdk-vpc-flow-logs-enabled_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-vpc-flow-logs-enabled@v1.0 defects=1}
+import {
+    FlowLog,
+    Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        new Vpc(Stack, 'rVpc');
+        // Noncompliant: `resourceType` is not set for FlowLog.
+        new FlowLog(Stack, 'rFlowLog');
+
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_apigw_authorization/typescript_cdk_apigw_authorization_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_apigw_authorization/typescript_cdk_apigw_authorization_compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-apigw-authorization@v1.0 defects=0}
+import {
+  AuthorizationType,
+  RestApi
+  } from 'aws-cdk-lib/aws-apigateway';
+  import { Stack } from 'aws-cdk-lib/core';
+  import * as cdk from 'aws-cdk-lib';
+  
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+		// Compliant: RestApi instantiation sets the `authorizationType` to CUSTOM, enabling authorization.
+		new RestApi(Stack, 'rRestApi', {
+			defaultMethodOptions: { authorizationType: AuthorizationType.CUSTOM },
+		}).root.addMethod('ANY');
+  	}
+} // {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_apigw_authorization/typescript_cdk_apigw_authorization_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_apigw_authorization/typescript_cdk_apigw_authorization_non-compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-apigw-authorization@v1.0 defects=1}
+import {
+  RestApi
+  } from 'aws-cdk-lib/aws-apigateway';
+  import { Stack } from 'aws-cdk-lib/core';
+  import * as cdk from 'aws-cdk-lib';
+  
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);   
+            
+        // Noncompliant: RestApi instantiation does not set the `authorizationType`, disabling authorization.
+        new RestApi(Stack, 'rRestApi').root.addMethod('ANY');
+
+    }
+} // {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_athena_incomplete_encryption/typescript_cdk_athena_incomplete_encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_athena_incomplete_encryption/typescript_cdk_athena_incomplete_encryption_compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-athena-incomplete-encryption@v1.0 defects=0}
+import { CfnWorkGroup } from 'aws-cdk-lib/aws-athena';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The CfnWorkGroup instantiation sets the `workGroupConfiguration` to encrypt the query result.
+		new CfnWorkGroup(this, `${this.roleName}CfnWorkGroup`, {
+			name: `${roleName}WorkGroup`,
+			recursiveDeleteOption: false,
+			state: "ENABLED",
+			tags: this.cfnTags,
+			workGroupConfiguration: { 
+				publishCloudWatchMetricsEnabled: true,
+				requesterPaysEnabled: false,
+				resultConfiguration: {
+				encryptionConfiguration: this.encryptionConfigurationProperty,
+				outputLocation: `s3://${this.athenaResultBucket.bucketName}/${roleName}/`,
+				},
+			},
+		});
+
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_athena_incomplete_encryption/typescript_cdk_athena_incomplete_encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_athena_incomplete_encryption/typescript_cdk_athena_incomplete_encryption_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-athena-incomplete-encryption@v1.0 defects=1}
+import { CfnWorkGroup } from 'aws-cdk-lib/aws-athena';
+import {Stack} from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		
+		// Noncompliant: The CfnWorkGroup instantiation does not set the `workGroupConfiguration` to encrypt the query result.
+		new CfnWorkGroup(Stack, 'rWorkgroup', {
+			name: 'foo',
+		});
+
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_bucket_enforce_ssl/typescript_cdk_bucket_enforce_ssl_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_bucket_enforce_ssl/typescript_cdk_bucket_enforce_ssl_compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-bucket-enforce-ssl@v1.0 defects=0}
+import * as s3 from "@aws-cdk/aws-s3";
+import * as cdk from "@aws-cdk/core";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The S3 Bucket instantiation sets `enforceSSL` to `true`.
+		const AnotherGoodBucket = new s3.Bucket(this, "s3-bucket", {
+			enforceSSL: true,
+		});
+		
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_bucket_enforce_ssl/typescript_cdk_bucket_enforce_ssl_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_bucket_enforce_ssl/typescript_cdk_bucket_enforce_ssl_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-bucket-enforce-ssl@v1.0 defects=1}
+import * as s3 from "@aws-cdk/aws-s3";
+import * as cdk from "@aws-cdk/core";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The S3 Bucket instantiation does not set `enforceSSL` to `true`.
+		const badBucket = new s3.Bucket(this, "s3-bucket-bad");
+		
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_codebuild_project_has_public_access/typescript_cdk_codebuild_project_has_public_access_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_codebuild_project_has_public_access/typescript_cdk_codebuild_project_has_public_access_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-codebuild-project-has-public-access@v1.0 defects=0}
+import * as s3 from '@aws-cdk/aws-s3';
+import * as cdk from '@aws-cdk/core';
+import * as codebuild from '@aws-cdk/aws-codebuild'
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild'
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		const bucket = new s3.Bucket()
+		// Compliant: Project instantiation does not set `badge` to `true`, making private resources publicly accessible.
+		const privateProject1 = codebuild.Project(this, 'privateProject1', {
+			source: codebuild.Source.s3({
+				bucket: bucket,
+				path: 'path/to/file.zip',
+			}),
+		})
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_codebuild_project_has_public_access/typescript_cdk_codebuild_project_has_public_access_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_codebuild_project_has_public_access/typescript_cdk_codebuild_project_has_public_access_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-codebuild-project-has-public-access@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core';
+import * as codebuild from '@aws-cdk/aws-codebuild'
+import * as cdk from 'aws-cdk-lib';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild'
+
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: Project instantiation sets `badge` to `true`, making private resources publicly accessible.
+		const publicProject1 = new codebuild.Project(this, 'publicProject', {
+			badge: true
+		})
+  	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_dax_missing_encryption/typescript_cdk_dax_missing_encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_dax_missing_encryption/typescript_cdk_dax_missing_encryption_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-dax-missing-encryption@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-dax';
+
+export class Stack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The CfnCluster instantiation sets `sseSpecification` property, enabling `sseEnabled` to `true`.
+		new CfnCluster(stack, 'rDax', {
+			iamRoleArn: new Role(stack, 'rDAXRole', {
+				assumedBy: new ServicePrincipal('dax.amazonaws.com'),
+			}).roleArn,
+			nodeType: 't3.small',
+			replicationFactor: 7,
+			sseSpecification: { sseEnabled: true },
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_dax_missing_encryption/typescript_cdk_dax_missing_encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_dax_missing_encryption/typescript_cdk_dax_missing_encryption_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-dax-missing-encryption@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-dax';
+
+export class Stack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The CfnCluster instantiation does not set `sseSpecification` property.
+		new CfnCluster(stack, 'rDax', {
+			iamRoleArn: new Role(stack, 'rDAXRole', {
+				assumedBy: new ServicePrincipal('dax.amazonaws.com'),
+			}).roleArn,
+			nodeType: 't3.small',
+			replicationFactor: 3,
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_document_db_cluster_log_exports/typescript_cdk_document_db_cluster_log_exports_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_document_db_cluster_log_exports/typescript_cdk_document_db_cluster_log_exports_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript_cdk_document_db_cluster_log_exports@v1.0 defects=0}
+import { CfnDBCluster, DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import { Aspects, Duration, SecretValue, Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+		
+		// Compliant: The CfnDBCluster instantiation sets `enableCloudwatchLogsExports`, enabling authenticate, createIndex, and dropCollection Log Exports.
+		new CfnDBCluster(Stack, 'rDatabaseCluster', {
+			masterUsername: SecretValue.secretsManager('foo').toString(),
+			masterUserPassword: SecretValue.secretsManager('bar').toString(),
+			enableCloudwatchLogsExports: [
+				'authenticate',
+				'createIndex',
+				'dropCollection',
+			],
+		});
+  	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_document_db_cluster_log_exports/typescript_cdk_document_db_cluster_log_exports_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_document_db_cluster_log_exports/typescript_cdk_document_db_cluster_log_exports_non-compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript_cdk_document_db_cluster_log_exports@v1.0 defects=1}
+import { CfnDBCluster, DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+InstanceType,
+InstanceClass,
+InstanceSize,
+Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+import { Aspects, Duration, SecretValue, Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+		
+		// Noncompliant: The DatabaseCluster instantiation does not set `enableCloudwatchLogsExports`.
+		new DatabaseCluster(Stack, 'rDatabaseCluster', {
+			instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+			vpc: new Vpc(Stack, 'rVpc'),
+			masterUser: {
+				username: SecretValue.secretsManager('foo').toString(),
+				password: SecretValue.secretsManager('bar'),
+			},
+		});
+  	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_eks_public_access_enabled/typescript_cdk_eks_public_access_enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_eks_public_access_enabled/typescript_cdk_eks_public_access_enabled_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-eks-public-access-enabled@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import {
+  Cluster,
+  EndpointAccess,
+  KubernetesVersion,
+} from "aws-cdk-lib/aws-eks";
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: Cluster instantiation sets `endpointAccess` to `EndpointAccess.PRIVATE`.
+		new Cluster(Stack, "rCustomEKS", {
+			version: KubernetesVersion.V1_14,
+			endpointAccess: EndpointAccess.PRIVATE,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_eks_public_access_enabled/typescript_cdk_eks_public_access_enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_eks_public_access_enabled/typescript_cdk_eks_public_access_enabled_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-eks-public-access-enabled@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import {
+  Cluster,
+  EndpointAccess,
+  KubernetesVersion,
+} from "aws-cdk-lib/aws-eks";
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: Cluster instantiation sets `endpointAccess` to `EndpointAccess.PUBLIC`.
+		new Cluster(Stack, "rCustomEKS", {
+			version: KubernetesVersion.V1_14,
+			endpointAccess: EndpointAccess.PUBLIC,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_elasticache_cluster_usage_of_default_port/typescript_cdk_elasticache_cluster_usage_of_default_port_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_elasticache_cluster_usage_of_default_port/typescript_cdk_elasticache_cluster_usage_of_default_port_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-cluster-usage-of-default-port@v1.0 defects=0}
+import {
+	CfnCacheCluster,
+	CfnReplicationGroup,
+} from "aws-cdk-lib/aws-elasticache";
+
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The CfnCacheCluster instantiation sets a custom port value of 42, overriding the default port.
+		new CfnCacheCluster(Stack, "rAec", {
+			cacheNodeType: "cache.t3.micro",
+			engine: "memcached",
+			numCacheNodes: 42,
+			port: 42,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_elasticache_cluster_usage_of_default_port/typescript_cdk_elasticache_cluster_usage_of_default_port_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_elasticache_cluster_usage_of_default_port/typescript_cdk_elasticache_cluster_usage_of_default_port_non-compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-cluster-usage-of-default-port@v1.0 defects=1}
+import {
+  CfnCacheCluster,
+} from "aws-cdk-lib/aws-elasticache";
+
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The CfnCacheCluster instantiation does not set a custom port value, using the default port instead.
+		new CfnCacheCluster(Stack, "rAec", {
+			cacheNodeType: "cache.t3.micro",
+			engine: "memcached",
+			numCacheNodes: 42,
+			port: 11211,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_kinesis_data_firehose_sse/typescript_cdk_kinesis_data_firehose_sse_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_kinesis_data_firehose_sse/typescript_cdk_kinesis_data_firehose_sse_compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kinesis-data-firehose-sse@v1.0 defects=0}
+
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { CfnDeliveryStream } from 'aws-cdk-lib/aws-kinesisfirehose';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Stack } from "aws-cdk-lib/core";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The CfnDeliveryStream sets `deliveryStreamEncryptionConfigurationInput`.
+		new CfnDeliveryStream(Stack, 'rKdf', {
+			s3DestinationConfiguration: {
+				bucketArn: new Bucket(Stack, 'rDeliveryBucket').bucketArn,
+				roleArn: new Role(Stack, 'rKdfRole', {
+				assumedBy: new ServicePrincipal('firehose.amazonaws.com'),
+				}).roleArn,
+			},
+			deliveryStreamEncryptionConfigurationInput: {
+				keyType: 'AWS_OWNED_CMK',
+			},
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_kinesis_data_firehose_sse/typescript_cdk_kinesis_data_firehose_sse_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_kinesis_data_firehose_sse/typescript_cdk_kinesis_data_firehose_sse_non-compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kinesis-data-firehose-sse@v1.0 defects=1}
+
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { CfnDeliveryStream } from 'aws-cdk-lib/aws-kinesisfirehose';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Stack } from "aws-cdk-lib/core";
+import * as cdk from 'aws-cdk-lib';
+
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The CfnDeliveryStream does not set `deliveryStreamEncFryptionConfigurationInput`
+		new CfnDeliveryStream(Stack, 'rKdf', {
+			s3DestinationConfiguration: {
+				bucketArn: new Bucket(Stack, 'rDeliveryBucket').bucketArn,
+				roleArn: new Role(Stack, 'rKdfRole', {
+				assumedBy: new ServicePrincipal('firehose.amazonaws.com'),
+				}).roleArn,
+			},
+		});
+	}
+}// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_kinesis_disabled_sse/typescript_cdk_kinesis_disabled_sse_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_kinesis_disabled_sse/typescript_cdk_kinesis_disabled_sse_compliant.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kinesis-disabled-sse@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { StreamEncryption, Stream, StreamMode } from 'aws-cdk-lib/aws-kinesis';
+
+
+export class CdkStarterStack extends cdk.Stack {
+	public readonly kinesisStream: Stream;
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps, encrypt: boolean) {
+		super(scope, id, props);
+		// Compliant: The Stream instantiation sets `encryption` to KMS.
+		new Stream(stack, 'rKds', { encryption: StreamEncryption.KMS });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_kinesis_disabled_sse/typescript_cdk_kinesis_disabled_sse_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_kinesis_disabled_sse/typescript_cdk_kinesis_disabled_sse_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kinesis-disabled-sse@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { StreamEncryption, Stream, StreamMode } from 'aws-cdk-lib/aws-kinesis';
+import { Duration } from 'aws-cdk-lib';
+
+
+export class CdkStarterStack extends cdk.Stack {
+  	public readonly kinesisStream: Stream;
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps, encrypt: boolean) {
+		super(scope, id, props);
+
+		// Noncompliant: The Stream sets `encryption` to UNENCRYPTED.
+		new Stream(stack, 'rKds', {
+			encryption: StreamEncryption.UNENCRYPTED,
+		});
+	}
+}   
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_neptunedb_database_authentication_disabled/typescript_cdk_neptunedb_database_authentication_disabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_neptunedb_database_authentication_disabled/typescript_cdk_neptunedb_database_authentication_disabled_compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptunedb-database-authentication-disabled@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+import { CfnDBCluster } from "aws-cdk-lib/aws-neptune";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The CfnDBCluster instantiation sets `iamAuthEnabled` to `true`.
+		new CfnDBCluster(Stack, "rDatabaseCluster", {
+			iamAuthEnabled: true,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_neptunedb_database_authentication_disabled/typescript_cdk_neptunedb_database_authentication_disabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_neptunedb_database_authentication_disabled/typescript_cdk_neptunedb_database_authentication_disabled_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptunedb-database-authentication-disabled@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+import { CfnDBCluster } from "aws-cdk-lib/aws-neptune";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The CfnDBCluster instantiation does not set `iamAuthEnabled`.
+		new CfnDBCluster(Stack, "rDatabaseCluster");
+
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_open_search_missing_node_to_node_encryption/typescript_cdk_open_search_missing_node_to_node_encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_open_search_missing_node_to_node_encryption/typescript_cdk_open_search_missing_node_to_node_encryption_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-missing-node-to-node-encryption@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import {
+  CfnDomain as LegacyCfnDomain
+} from 'aws-cdk-lib/aws-elasticsearch';
+
+import { Stack } from 'aws-cdk-lib/core';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The LegacyCfnDomain instantiation sets the `nodeToNodeEncryptionOptions` property with NodeToNodeEncryptionOptionsProperty, enabling encryption at rest.
+		new LegacyCfnDomain(Stack, 'Domain', {
+			nodeToNodeEncryptionOptions: {
+				enabled: true,
+			},
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_open_search_missing_node_to_node_encryption/typescript_cdk_open_search_missing_node_to_node_encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_open_search_missing_node_to_node_encryption/typescript_cdk_open_search_missing_node_to_node_encryption_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-missing-node-to-node-encryption@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import {
+  CfnDomain as LegacyCfnDomain
+} from 'aws-cdk-lib/aws-elasticsearch';
+import { Stack } from 'aws-cdk-lib/core';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The LegacyCfnDomain instantiation does not set the `nodeToNodeEncryptionOptions`.
+		new LegacyCfnDomain(Stack, 'Domain', {});
+		
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_public_s3_bucket/typescript_cdk_public_s3_bucket_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_public_s3_bucket/typescript_cdk_public_s3_bucket_compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-public-s3-bucket@v1.0 defects=0}
+import * as cdk from '@aws-cdk/core';
+import * as rename_s3  from '@aws-cdk/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+import * as rename_s3  from 'aws-cdk-lib/aws-s3';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: Bucket has public access disabled.
+		const nonPublicBucketRenamed = new rename_s3.Bucket(this, 'bucket')
+
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_public_s3_bucket/typescript_cdk_public_s3_bucket_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_public_s3_bucket/typescript_cdk_public_s3_bucket_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-public-s3-bucket@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		// Noncompliant: Bucket has public access which is security sensitive.
+		const publicBucket1 = new s3.Bucket(this, 'bucket')
+		console.log('something unrelated')
+		publicBucket1.grantPublicAccess()
+
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_rds_deletion_protection_enabled/typescript_cdk_rds_deletion_protection_enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_rds_deletion_protection_enabled/typescript_cdk_rds_deletion_protection_enabled_compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-deletion-protection-enabled@v1.0 defects=0}
+import { Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine
+} from "aws-cdk-lib/aws-rds";
+import * as cdk from 'aws-cdk-lib';
+
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		const shouldEnableDeletionProtection = false;
+
+		// Compliant: The DatabaseCluster instantiation sets `deletionProtection` to `true`.
+		new DatabaseCluster(Stack, "rDbCluster", {
+			engine: DatabaseClusterEngine.auroraMysql({
+				version: AuroraMysqlEngineVersion.VER_5_7_12,
+			}),
+			instanceProps: { vpc: new Vpc(Stack, "rnew Vpc") },
+			deletionProtection: true,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_rds_deletion_protection_enabled/typescript_cdk_rds_deletion_protection_enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_rds_deletion_protection_enabled/typescript_cdk_rds_deletion_protection_enabled_non-compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-deletion-protection-enabled@v1.0 defects=1}
+import { Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+
+} from "aws-cdk-lib/aws-rds";
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		const shouldEnableDeletionProtection = false;
+
+		// Noncompliant: `deletionProtection` in `DatabaseCluster` is disabled.
+		new DatabaseCluster(Stack, "rDbCluster", {
+			engine: DatabaseClusterEngine.auroraMysql({
+				version: AuroraMysqlEngineVersion.VER_5_7_12,
+			}),
+			instanceProps: { vpc:new Vpc(Stack, "rnew Vpc") },
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_redshift_cluster_usage_of_default_port/typescript_cdk_redshift_cluster_usage_of_default_port_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_redshift_cluster_usage_of_default_port/typescript_cdk_redshift_cluster_usage_of_default_port_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-usage-of-default-port@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: The CfnCluster instantiation sets a custom port value of 42, overriding the default port.
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: 'use_a_secret_here',
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+			port: 42,
+		});  
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_redshift_cluster_usage_of_default_port/typescript_cdk_redshift_cluster_usage_of_default_port_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_redshift_cluster_usage_of_default_port/typescript_cdk_redshift_cluster_usage_of_default_port_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-usage-of-default-port@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Noncompliant: The CfnCluster instantiation does not have a custom port value, using the default port instead.
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: 'use_a_secret_here',
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_redshift_missing_encryption/typescript_cdk_redshift_missing_encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_redshift_missing_encryption/typescript_cdk_redshift_missing_encryption_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-missing-encryption@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib/core';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		
+		// Compliant: Encryption at rest is enabled.
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: 'use_a_secret_here',
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+			encrypted: true,
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_redshift_missing_encryption/typescript_cdk_redshift_missing_encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_redshift_missing_encryption/typescript_cdk_redshift_missing_encryption_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-missing-encryption@v1.0 defects=1}
+import { CfnCluster} from 'aws-cdk-lib/aws-redshift';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib/core';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		
+		// Noncompliant: Encryption at rest is disabled.
+		new CfnCluster(Stack, 'rRedshiftCluster', {
+			masterUsername: 'use_a_secret_here',
+			masterUserPassword: 'use_a_secret_here',
+			clusterType: 'single-node',
+			dbName: 'bar',
+			nodeType: 'ds2.xlarge',
+		});
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_sns_missing_severside_encryption/typescript_cdk_sns_missing_severside_encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_sns_missing_severside_encryption/typescript_cdk_sns_missing_severside_encryption_compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sns-missing-severside-encryption@v1.0 defects=0}
+import { Key } from "aws-cdk-lib/aws-kms";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Stack } from "aws-cdk-lib/core";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		// Compliant: SNS topics is encrypted via `masterKey`.
+		new Topic(Stack, "rTopic", { masterKey: new Key(Stack, "rKey") });
+
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_sns_missing_severside_encryption/typescript_cdk_sns_missing_severside_encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_sns_missing_severside_encryption/typescript_cdk_sns_missing_severside_encryption_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sns-missing-severside-encryption@v1.0 defects=1}
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Stack } from "aws-cdk-lib/core";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+		
+		// Noncompliant: SNS topics is not encrypted via `masterKey`.
+		new Topic(Stack, "rTopic");
+	
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_sqs_queue_sse/typescript_cdk_sqs_queue_sse_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_sqs_queue_sse/typescript_cdk_sqs_queue_sse_compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+
+// {fact rule=typescript-cdk-sqs-queue-sse@v1.0 defects=0}
+import { Queue, QueueEncryption } from 'aws-cdk-lib/aws-sqs';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+import { Key } from 'aws-cdk-lib/aws-kms';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);      
+
+        // Compliant: SQS Queue has server-side encryption enabled.
+        new Queue(Stack, 'rQueue', {
+            encryptionMasterKey: new Key(Stack, 'rQueueKey'),
+        });
+    }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript_cdk_sqs_queue_sse/typescript_cdk_sqs_queue_sse_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript_cdk_sqs_queue_sse/typescript_cdk_sqs_queue_sse_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+
+// {fact rule=typescript-cdk-sqs-queue-sse@v1.0 defects=1}
+import { Queue, QueueEncryption } from 'aws-cdk-lib/aws-sqs';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+
+		// Noncompliant: SQS Queue has server-side encryption disabled.
+		new Queue(Stack, 'rQueue', {
+			encryption: QueueEncryption.UNENCRYPTED,
+		});
+	}
+}
+// {/fact}


### PR DESCRIPTION
Add non compliant and compliant samples for typescript_cdk detectors.

Note: All the test cases have 100% recall and precision.