### PR TITLE
Correct noncompliant and compliant sample for CPP 'c-cpp-incorrect-unsigned-comparison' rule.

### DIFF
--- a/cpp/src/detectors/c-cpp-incorrect-unsigned-comparison/c-cpp-incorrect-unsigned-comparison_compliant.cpp
+++ b/cpp/src/detectors/c-cpp-incorrect-unsigned-comparison/c-cpp-incorrect-unsigned-comparison_compliant.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 // {fact rule=c-cpp-incorrect-unsigned-comparison@v1.0 defects=0}
+#include <cstddef>
 
 int compliant() {
     unsigned short uvar;

--- a/cpp/src/detectors/c-cpp-incorrect-unsigned-comparison/c-cpp-incorrect-unsigned-comparison_non-compliant.cpp
+++ b/cpp/src/detectors/c-cpp-incorrect-unsigned-comparison/c-cpp-incorrect-unsigned-comparison_non-compliant.cpp
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-// {fact rule=incorrect-comparison@v1.0 defects=1}
+// {fact rule=c-cpp-incorrect-unsigned-comparison@v1.0 defects=1}
 #include <cstddef>
 
 int noncompliant() {
     size_t uvar;
 
-    // Noncompliant: `size_t` variable can't be less than 0.
+    // Noncompliant: `size_t` variable can never be less than 0.
     if (uvar <= 0)
         return 1;
 


### PR DESCRIPTION
Made corrections to the noncompliant and compliant sample for 'c-cpp-incorrect-unsigned-comparison' rule.
