### PR TITLE
Added DL cases for typescript cdk

### DIFF
--- a/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_compliant.ts
@@ -7,14 +7,14 @@ import * as cdk from 'aws-cdk-lib';
 import { Stack } from 'aws-cdk-lib';
 
 export class CdkStarterStack extends cdk.Stack {
-	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
-    super(scope, id, props);      
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
     // Compliant: Configures logging with CloudWatch for monitoring API access and invalid requests.
     new CfnGraphQLApi(Stack, 'rGraphqlApi', {
       authenticationType: 'AMAZON_COGNITO_USER_POOL',
       name: 'foo',
       logConfig: { cloudWatchLogsRoleArn: 'foo' }
     });
-	}
+  }
 }
 // {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-app-sync-graph-ql-request-logging@v1.0 defects=0}
+import { CfnGraphQLApi } from 'aws-cdk-lib/aws-appsync';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);      
+    // Compliant: Configures logging with CloudWatch for monitoring API access and invalid requests.
+    new CfnGraphQLApi(Stack, 'rGraphqlApi', {
+      authenticationType: 'AMAZON_COGNITO_USER_POOL',
+      name: 'foo',
+      logConfig: { cloudWatchLogsRoleArn: 'foo' }
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_non-compliant.ts
@@ -7,14 +7,14 @@ import * as cdk from 'aws-cdk-lib';
 import { Stack } from 'aws-cdk-lib';
 
 export class CdkStarterStack extends cdk.Stack {
-	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
-		super(scope, id, props);      
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
     // Noncomplaint: Missing request-level logging, reducing visibility into API access and usage.
     new CfnGraphQLApi(Stack, 'rGraphqlApi', {
       authenticationType: 'AMAZON_COGNITO_USER_POOL',
       name: 'foo',
       logConfig: { excludeVerboseContent: true }
     });
-	}
+  }
 }
 // {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-app-sync-graph-ql-request-logging/typescript-cdk-app-sync-graph-ql-request-logging_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-app-sync-graph-ql-request-logging@v1.0 defects=1}
+import { CfnGraphQLApi } from 'aws-cdk-lib/aws-appsync';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    // Noncomplaint: Missing request-level logging, reducing visibility into API access and usage.
+    new CfnGraphQLApi(Stack, 'rGraphqlApi', {
+      authenticationType: 'AMAZON_COGNITO_USER_POOL',
+      name: 'foo',
+      logConfig: { excludeVerboseContent: true }
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-postgres-iam-auth/typescript-cdk-aurora-my-sql-postgres-iam-auth_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-postgres-iam-auth/typescript-cdk-aurora-my-sql-postgres-iam-auth_compliant.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-aurora-my-postgres-iam-auth@v1.0 defects=0}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine
+} from 'aws-cdk-lib/aws-rds';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses IAM authentication for database access, enhancing security.
+    const vpc = new Vpc(Stack, 'rVpc');
+    new DatabaseCluster(Stack, 'rDbCluster', {
+      engine: DatabaseClusterEngine.auroraMysql({
+        version: AuroraMysqlEngineVersion.VER_5_7_12,
+      }),
+      iamAuthentication: true,
+      instanceProps: { vpc: vpc }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-postgres-iam-auth/typescript-cdk-aurora-my-sql-postgres-iam-auth_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aurora-my-sql-postgres-iam-auth/typescript-cdk-aurora-my-sql-postgres-iam-auth_non-compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-aurora-my-postgres-iam-auth@v1.0 defects=1}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AuroraMysqlEngineVersion,
+  DatabaseCluster,
+  DatabaseClusterEngine
+} from 'aws-cdk-lib/aws-rds';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Disables IAM authentication, relying on less secure authentication methods.
+    new DatabaseCluster(Stack, 'rDbCluster', {
+      engine: DatabaseClusterEngine.auroraMysql({
+        version: AuroraMysqlEngineVersion.VER_5_7_12,
+      }),
+      instanceProps: { vpc: new Vpc(Stack, 'rVpc') },
+      iamAuthentication: false
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cloud-9-instance-no-ingress-systems-manager/typescript-cdk-cloud-9-instance-no-ingress-systems-manager_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cloud-9-instance-no-ingress-systems-manager/typescript-cdk-cloud-9-instance-no-ingress-systems-manager_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cloud-9-instance-no-ingress-systems-manager@v1.0 defects=0}
+import { CfnEnvironmentEC2 } from 'aws-cdk-lib/aws-cloud9';
+import { InstanceType, InstanceClass, InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses `CONNECT_SSM` for secure, managed connections to the EC2 instance.
+    new CfnEnvironmentEC2(Stack, 'rC9Env', {
+      instanceType: InstanceType.of(
+        InstanceClass.T2,
+        InstanceSize.MICRO
+      ).toString(),
+      connectionType: 'CONNECT_SSM'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cloud-9-instance-no-ingress-systems-manager/typescript-cdk-cloud-9-instance-no-ingress-systems-manager_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cloud-9-instance-no-ingress-systems-manager/typescript-cdk-cloud-9-instance-no-ingress-systems-manager_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cloud-9-instance-no-ingress-systems-manager@v1.0 defects=1}
+import { CfnEnvironmentEC2 } from 'aws-cdk-lib/aws-cloud9';
+import { InstanceType, InstanceClass, InstanceSize } from 'aws-cdk-lib/aws-ec2';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Lacks `CONNECT_SSM`, exposing the instance to less secure connection methods.
+    new CfnEnvironmentEC2(Stack, 'rC9Env', {
+      instanceType: InstanceType.of(
+        InstanceClass.T2,
+        InstanceSize.MICRO
+      ).toString()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-encryption-at-rest/typescript-cdk-document-db-cluster-encryption-at-rest_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-encryption-at-rest/typescript-cdk-document-db-cluster-encryption-at-rest_compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-encryption-at-rest@v1.0 defects=0}
+import { DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import { Stack, SecretValue } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables storage encryption, ensuring data at rest is secure.
+    new DatabaseCluster(Stack, 'rDatabaseCluster', {
+      instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+      vpc: new Vpc(Stack, 'rVpc'),
+      masterUser: {
+        username: SecretValue.secretsManager('foo').toString(),
+        password: SecretValue.secretsManager('bar'),
+      },
+      storageEncrypted: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-encryption-at-rest/typescript-cdk-document-db-cluster-encryption-at-rest_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-encryption-at-rest/typescript-cdk-document-db-cluster-encryption-at-rest_non-compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-encryption-at-rest@v1.0 defects=1}
+import { DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import { Stack, SecretValue } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables storage encryption, potentially exposing sensitive data.
+    new DatabaseCluster(Stack, 'rDatabaseCluster', {
+      instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+      vpc: new Vpc(Stack, 'rVpc'),
+      masterUser: {
+        username: SecretValue.secretsManager('foo').toString(),
+        password: SecretValue.secretsManager('bar'),
+      },
+      storageEncrypted: false
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-non-default-port/typescript-cdk-document-db-cluster-non-default-port_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-non-default-port/typescript-cdk-document-db-cluster-non-default-port_compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-non-default-port@v1.0 defects=0}
+import { DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import { Stack, SecretValue } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Uses a custom port to improve security.
+    new DatabaseCluster(Stack, 'rDatabaseCluster', {
+      instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+      vpc: new Vpc(Stack, 'rVpc'),
+      masterUser: {
+        username: SecretValue.secretsManager('foo').toString(),
+        password: SecretValue.secretsManager('bar'),
+      },
+      port: 42
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-non-default-port/typescript-cdk-document-db-cluster-non-default-port_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-non-default-port/typescript-cdk-document-db-cluster-non-default-port_non-compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-non-default-port@v1.0 defects=1}
+import { DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import { Stack, SecretValue } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses the default port, increasing potential security risks.
+    new DatabaseCluster(Stack, 'rDatabaseCluster', {
+      instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+      vpc: new Vpc(Stack, 'rVpc'),
+      masterUser: {
+        username: SecretValue.secretsManager('foo').toString(),
+        password: SecretValue.secretsManager('bar')
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ecs-cluster-cloud-watch-container-insights/typescript-cdk-ecs-cluster-cloud-watch-container-insights_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ecs-cluster-cloud-watch-container-insights/typescript-cdk-ecs-cluster-cloud-watch-container-insights_compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ecs-cluster-cloud-watch-container-insights@v1.0 defects=0}
+import {
+  Cluster
+} from 'aws-cdk-lib/aws-ecs';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint:  Enables container insights for better monitoring and performance tracking.
+    new Cluster(Stack, 'rCluster', { containerInsights: true });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ecs-cluster-cloud-watch-container-insights/typescript-cdk-ecs-cluster-cloud-watch-container-insights_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ecs-cluster-cloud-watch-container-insights/typescript-cdk-ecs-cluster-cloud-watch-container-insights_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ecs-cluster-cloud-watch-container-insights@v1.0 defects=1}
+import {
+  Cluster
+} from 'aws-cdk-lib/aws-ecs';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables container insights, limiting visibility into cluster performance.
+    new Cluster(Stack, 'rCluster', { containerInsights: false });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-efs-encrypted/typescript-cdk-efs-encrypted_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-efs-encrypted/typescript-cdk-efs-encrypted_compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-efs-encrypted@v1.0 defects=0}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { FileSystem } from 'aws-cdk-lib/aws-efs';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: EFS is created with encryption enabled, ensuring data security at rest.
+    new FileSystem(Stack, 'rEFS', {
+      vpc: new Vpc(Stack, 'rVpc')
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-efs-encrypted/typescript-cdk-efs-encrypted_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-efs-encrypted/typescript-cdk-efs-encrypted_non-compliant.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-efs-encrypted@v1.0 defects=1}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { FileSystem } from 'aws-cdk-lib/aws-efs';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: EFS is created without encryption, exposing data to potential security risks.
+    new FileSystem(Stack, 'rEFS', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      encrypted: false
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-encryption/typescript-cdk-elasticache-missing-encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-encryption/typescript-cdk-elasticache-missing-encryption_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-missing-encryption@v1.0 defects=0}
+import {
+  CfnReplicationGroup
+} from "aws-cdk-lib/aws-elasticache";
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Transit encryption is enabled, securing data in transit.
+    new CfnReplicationGroup(Stack, "rRedisGroup", {
+      cacheNodeType: "cache.t3.micro",
+      engine: "redis",
+      replicationGroupDescription: "lorem ipsum dolor sit amet",
+      cacheSubnetGroupName: "lorem",
+      atRestEncryptionEnabled: true,
+      transitEncryptionEnabled: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-encryption/typescript-cdk-elasticache-missing-encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-encryption/typescript-cdk-elasticache-missing-encryption_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-missing-encryption@v1.0 defects=1}
+import {
+  CfnReplicationGroup
+} from "aws-cdk-lib/aws-elasticache";
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Transit encryption is not enabled, exposing data in transit.
+    new CfnReplicationGroup(Stack, "rRedisGroup", {
+      cacheNodeType: "cache.t3.micro",
+      engine: "redis",
+      replicationGroupDescription: "lorem ipsum dolor sit amet",
+      atRestEncryptionEnabled: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-multiaz-encryption/typescript-cdk-elasticache-missing-multiaz-encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-multiaz-encryption/typescript-cdk-elasticache-missing-multiaz-encryption_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-missing-multiAz-encryption@v1.0 defects=0}
+import {
+    CfnReplicationGroup
+} from 'aws-cdk-lib/aws-elasticache';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Enables Multi-AZ deployment for high availability and failover support.
+    new CfnReplicationGroup(Stack, 'rRedisGroup', {
+      cacheNodeType: 'cache.t3.micro',
+      engine: 'redis',
+      replicationGroupDescription: 'lorem ipsum dolor sit amet',
+      cacheSubnetGroupName: 'lorem',
+      multiAzEnabled: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-multiaz-encryption/typescript-cdk-elasticache-missing-multiaz-encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-multiaz-encryption/typescript-cdk-elasticache-missing-multiaz-encryption_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-missing-multiAz-encryption@v1.0 defects=1}
+import {
+    CfnReplicationGroup
+} from 'aws-cdk-lib/aws-elasticache';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Does not enable Multi-AZ, reducing availability and fault tolerance.
+    new CfnReplicationGroup(Stack, 'rRedisGroup', {
+      cacheNodeType: 'cache.t3.micro',
+      engine: 'redis',
+      replicationGroupDescription: 'lorem ipsum dolor sit amet',
+    });
+  }
+}
+// {/fact}


### PR DESCRIPTION
Added non compliant and compliant samples for typescript cdk detectors.

Note: All the test cases have 100% recall and prescision.