### PR TITLE
Added DL cases for typescript cdk

### DIFF
--- a/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-cooldown-period/typescript-cdk-auto-scaling-group-cooldown-period_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-cooldown-period/typescript-cdk-auto-scaling-group-cooldown-period_compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-auto-scaling-group-cooldown-period@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack, Duration } from 'aws-cdk-lib';
+import {
+  AutoScalingGroup
+} from 'aws-cdk-lib/aws-autoscaling';
+import {
+  InstanceClass,
+  InstanceType,
+  MachineImage,
+  Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Sets a proper cooldown to avoid rapid scaling.
+    new AutoScalingGroup(Stack, 'rAsg', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      instanceType: new InstanceType(InstanceClass.T3),
+      machineImage: MachineImage.latestAmazonLinux(),
+      cooldown: Duration.seconds(42)
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-cooldown-period/typescript-cdk-auto-scaling-group-cooldown-period_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-cooldown-period/typescript-cdk-auto-scaling-group-cooldown-period_non-compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-auto-scaling-group-cooldown-period@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack, Duration } from 'aws-cdk-lib';
+import {
+  AutoScalingGroup
+} from 'aws-cdk-lib/aws-autoscaling';
+import {
+  InstanceClass,
+  InstanceType,
+  MachineImage,
+  Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: No cooldown, leading to potential rapid, uncoordinated scaling.
+    new AutoScalingGroup(Stack, 'rAsg', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      instanceType: new InstanceType(InstanceClass.T3),
+      machineImage: MachineImage.latestAmazonLinux(),
+      cooldown: Duration.seconds(0)
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-health-check/typescript-cdk-auto-scaling-group-health-check_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-health-check/typescript-cdk-auto-scaling-group-health-check_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-auto-scaling-group-health-check@v1.0 defects=0}
+import {
+  CfnAutoScalingGroup
+} from 'aws-cdk-lib/aws-autoscaling';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses `EC2` health check, suitable for EC2-based scaling.
+    new CfnAutoScalingGroup(Stack, 'rAsg', {
+      minSize: '7',
+      maxSize: '42',
+      healthCheckType: 'EC2'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-health-check/typescript-cdk-auto-scaling-group-health-check_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-health-check/typescript-cdk-auto-scaling-group-health-check_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-auto-scaling-group-health-check@v1.0 defects=1}
+import {
+  CfnAutoScalingGroup
+} from 'aws-cdk-lib/aws-autoscaling';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Uses `ELB` health check without a load balancer, causing potential misconfigurations.
+    new CfnAutoScalingGroup(Stack, 'rAsg', {
+      minSize: '7',
+      maxSize: '42',
+      healthCheckType: 'ELB'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-redis-authorization/typescript-cdk-elasticache-missing-redis-authorization_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-redis-authorization/typescript-cdk-elasticache-missing-redis-authorization_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-missing-redis-authorization@v1.0 defects=0}
+import {
+  CfnReplicationGroup
+} from 'aws-cdk-lib/aws-elasticache';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses Secrets Manager for `authToken`.
+    new CfnReplicationGroup(Stack, 'rRedisGroup', {
+      cacheNodeType: 'cache.t3.micro',
+      replicationGroupDescription: 'lorem ipsum dolor sit amet',
+      cacheSubnetGroupName: 'lorem',
+      transitEncryptionEnabled: true,
+      authToken: SecretValue.secretsManager('foo').toString(),
+      port: 42
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-redis-authorization/typescript-cdk-elasticache-missing-redis-authorization_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elasticache-missing-redis-authorization/typescript-cdk-elasticache-missing-redis-authorization_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elasticache-missing-redis-authorization@v1.0 defects=1}
+import {
+  CfnReplicationGroup
+} from 'aws-cdk-lib/aws-elasticache';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses plaintext for `authToken`.
+    new CfnReplicationGroup(Stack, 'rRedisGroup', {
+      cacheNodeType: 'cache.t3.micro',
+      engine: 'redis',
+      replicationGroupDescription: 'lorem ipsum dolor sit amet',
+      transitEncryptionEnabled: false,
+      authToken:"Foo"
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-enabled-access-logging-for-cloudfront-distribution/typescript-cdk-enabled-access-logging-for-cloudfront-distribution_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-enabled-access-logging-for-cloudfront-distribution/typescript-cdk-enabled-access-logging-for-cloudfront-distribution_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-enabled-access-logging-for-cloudfront-distribution@v1.0 defects=0}
+import {
+  Distribution
+} from 'aws-cdk-lib/aws-cloudfront';
+import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Specifies `logBucket` for logging.
+    const logsBucket = new Bucket(Stack, 'rLoggingBucket');
+    new Distribution(Stack, 'rDistribution', {
+      defaultBehavior: {
+        origin: new S3Origin(new Bucket(Stack, 'rOriginBucket')),
+      },
+      logBucket: logsBucket
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-enabled-access-logging-for-cloudfront-distribution/typescript-cdk-enabled-access-logging-for-cloudfront-distribution_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-enabled-access-logging-for-cloudfront-distribution/typescript-cdk-enabled-access-logging-for-cloudfront-distribution_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-enabled-access-logging-for-cloudfront-distribution@v1.0 defects=1}
+import {
+  Distribution
+} from 'aws-cdk-lib/aws-cloudfront';
+import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Missing `logBucket` for logging.
+    new Distribution(Stack, 'rDistribution', {
+      defaultBehavior: {
+        origin: new S3Origin(new Bucket(Stack, 'rOriginBucket'))
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-internet-access-enabled-for-sagemaker-notebook/typescript-cdk-internet-access-enabled-for-sagemaker-notebook_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-internet-access-enabled-for-sagemaker-notebook/typescript-cdk-internet-access-enabled-for-sagemaker-notebook_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-internet-access-enabled-for-sagemaker-notebook@v1.0 defects=0}
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+  CfnNotebookInstance,
+} from 'aws-cdk-lib/aws-sagemaker';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Disables direct internet access for security.
+    new CfnNotebookInstance(Stack, 'rNotebook', {
+      instanceType: 'ml.t3.xlarge',
+      roleArn: new Role(Stack, 'rNotebookRole', {
+        assumedBy: new ServicePrincipal('sagemaker.amazonaws.com'),
+      }).roleArn,
+      subnetId: 'subnet-0bb1c79de3EXAMPLE',
+      directInternetAccess: 'Disabled'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-internet-access-enabled-for-sagemaker-notebook/typescript-cdk-internet-access-enabled-for-sagemaker-notebook_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-internet-access-enabled-for-sagemaker-notebook/typescript-cdk-internet-access-enabled-for-sagemaker-notebook_non-compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-internet-access-enabled-for-sagemaker-notebook@v1.0 defects=1}
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+  CfnNotebookInstance
+} from 'aws-cdk-lib/aws-sagemaker';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Enables direct internet access, increasing security risks.
+    new CfnNotebookInstance(Stack, 'rNotebook', {
+      instanceType: 'ml.t3.xlarge',
+      roleArn: new Role(Stack, 'rNotebookRole', {
+        assumedBy: new ServicePrincipal('sagemaker.amazonaws.com'),
+      }).roleArn,
+      subnetId: 'subnet-0bb1c79de3EXAMPLE',
+      directInternetAccess: 'Enabled'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-kms-backing-key-rotation-enabled/typescript-cdk-kms-backing-key-rotation-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-kms-backing-key-rotation-enabled/typescript-cdk-kms-backing-key-rotation-enabled_compliant.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kms-backing-key-rotation-enabled@v1.0 defects=0}
+import { Key } from 'aws-cdk-lib/aws-kms';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);        
+	// Compliant: Enables key rotation for improved security.
+	new Key(Stack, 'rSymmetricKey', { enableKeyRotation: true });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-kms-backing-key-rotation-enabled/typescript-cdk-kms-backing-key-rotation-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-kms-backing-key-rotation-enabled/typescript-cdk-kms-backing-key-rotation-enabled_non-compliant.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-kms-backing-key-rotation-enabled@v1.0 defects=1}
+import { Key } from 'aws-cdk-lib/aws-kms';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);      
+	// Noncomplaint: Key rotation is not enabled, reducing security best practices.
+	new Key(Stack, 'rSymmetricKey');
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-media-store-container-access-logging/typescript-cdk-media-store-container-access-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-media-store-container-access-logging/typescript-cdk-media-store-container-access-logging_compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-media-store-container-access-logging@v1.0 defects=0}
+import { CfnContainer } from 'aws-cdk-lib/aws-mediastore';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Enables access logging for monitoring and security.
+    new CfnContainer(Stack, 'rMsContainer', {
+      containerName: 'foo',
+      accessLoggingEnabled: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-media-store-container-access-logging/typescript-cdk-media-store-container-access-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-media-store-container-access-logging/typescript-cdk-media-store-container-access-logging_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-media-store-container-access-logging@v1.0 defects=1}
+import { CfnContainer } from 'aws-cdk-lib/aws-mediastore';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Access logging is disabled, missing security and auditability.
+    new CfnContainer(Stack, 'rMsContainer', {
+      containerName: 'foo'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-publicly-accessible-redshift-cluster/typescript-cdk-publicly-accessible-redshift-cluster_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-publicly-accessible-redshift-cluster/typescript-cdk-publicly-accessible-redshift-cluster_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-publicly-accessible-redshift-cluster@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Does not expose the cluster publicly, maintaining security.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'awsuser',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-publicly-accessible-redshift-cluster/typescript-cdk-publicly-accessible-redshift-cluster_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-publicly-accessible-redshift-cluster/typescript-cdk-publicly-accessible-redshift-cluster_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-publicly-accessible-redshift-cluster@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Exposes the cluster publicly, increasing security risks.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'awsuser',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      publiclyAccessible: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-default-username/typescript-cdk-redshift-default-username_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-default-username/typescript-cdk-redshift-default-username_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-default-username@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses the standard `awsuser` for consistency and security best practices.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'notawsuser',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge'
+    });
+ }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-default-username/typescript-cdk-redshift-default-username_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-default-username/typescript-cdk-redshift-default-username_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-default-username@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Uses a non-standard `masterUsername` (`notawsuser`), which can lead to confusion and inconsistent management.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'awsuser',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge'
+    });
+ }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-s3-partial-encrypt/typescript-cdk-s3-partial-encrypt_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-s3-partial-encrypt/typescript-cdk-s3-partial-encrypt_compliant.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-s3-partial-encrypt@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import {Bucket, BucketEncryption} from 'aws-cdk-lib/aws-s3';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Enables encryption for data security.
+    const goodBucketDirect = new Bucket(this, 's3-bucket', {
+      encryption: BucketEncryption.S3_MANAGED
+    })
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-s3-partial-encrypt/typescript-cdk-s3-partial-encrypt_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-s3-partial-encrypt/typescript-cdk-s3-partial-encrypt_non-compliant.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-s3-partial-encrypt@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Lacks encryption, leaving data unprotected.
+    const badBucketDirect = new Bucket(this, 's3-bucket-bad')
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sagemaker-notebook-missing-encryption/typescript-cdk-sagemaker-notebook-missing-encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sagemaker-notebook-missing-encryption/typescript-cdk-sagemaker-notebook-missing-encryption_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sagemaker-notebook-missing-encryption@v1.0 defects=0}
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+  CfnNotebookInstance,
+} from 'aws-cdk-lib/aws-sagemaker';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Specifies a `kmsKeyId` for encryption, securing data at rest.
+    new CfnNotebookInstance(Stack, 'rNotebook', {
+      instanceType: 'ml.t3.xlarge',
+      roleArn: new Role(Stack, 'rNotebookRole', {
+        assumedBy: new ServicePrincipal('sagemaker.amazonaws.com'),
+      }).roleArn,
+      kmsKeyId: '1234abcd-12ab-34cd-56ef-1234567890ab'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sagemaker-notebook-missing-encryption/typescript-cdk-sagemaker-notebook-missing-encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sagemaker-notebook-missing-encryption/typescript-cdk-sagemaker-notebook-missing-encryption_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sagemaker-notebook-missing-encryption@v1.0 defects=1}
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+  CfnNotebookInstance,
+} from 'aws-cdk-lib/aws-sagemaker';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Omits `kmsKeyId`, leaving data potentially unencrypted.
+    new CfnNotebookInstance(Stack, 'rNotebook', {
+      instanceType: 'ml.t3.xlarge',
+      roleArn: new Role(Stack, 'rNotebookRole', {
+        assumedBy: new ServicePrincipal('sagemaker.amazonaws.com'),
+      }).roleArn
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-step-function-state-machine-xray/typescript-cdk-step-function-state-machine-xray_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-step-function-state-machine-xray/typescript-cdk-step-function-state-machine-xray_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-step-function-state-machine-xray@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import {
+  StateMachine,
+  Wait,
+  WaitTime
+} from 'aws-cdk-lib/aws-stepfunctions';
+import { Duration, Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Complaint: Enables tracing for monitoring and debugging purposes.
+    new StateMachine(Stack, 'rStateMachine', {
+      definition: new Wait(Stack, 'rWait30', {
+        time: WaitTime.duration(Duration.seconds(30)),
+      }),
+      tracingEnabled: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-step-function-state-machine-xray/typescript-cdk-step-function-state-machine-xray_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-step-function-state-machine-xray/typescript-cdk-step-function-state-machine-xray_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-step-function-state-machine-xray@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import {
+  StateMachine,
+  Wait,
+  WaitTime
+} from 'aws-cdk-lib/aws-stepfunctions';
+import { Duration, Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables tracing, reducing visibility into the state machine's execution.
+    new StateMachine(Stack, 'rStateMachine', {
+      definition: new Wait(Stack, 'rWait30', {
+        time: WaitTime.duration(Duration.seconds(30)),
+      })
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution@v1.0 defects=0}
+import {
+    Distribution
+} from 'aws-cdk-lib/aws-cloudfront';
+import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses an S3 origin, ensuring proper integration with S3 for content delivery.
+    new Distribution(Stack, 'rDistribution', {
+      defaultBehavior: {
+      origin: new S3Origin(new Bucket(Stack, 'rOriginBucket'))
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution/typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-usage-of-origin-access-identity-for-cloudfront-distribution@v1.0 defects=1}
+import {
+    Distribution
+} from 'aws-cdk-lib/aws-cloudfront';
+import { HttpOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncomplaint: Uses an HTTP origin, which may cause security and performance issues.
+    new Distribution(Stack, 'rDistribution', {
+      defaultBehavior: {
+        origin: new HttpOrigin('foo.s3-website.amazonaws.com')
+      }
+    });
+  }
+}
+// {/fact}


### PR DESCRIPTION
Adding compliant and non compliant samples for typescript cdk detectors.

Note: All the test cases have 100% recall and precision.