### PR TITLE
Added DL cases for typescript cdk

### DIFF
--- a/cdk_typescript/src/detectors/typescript-cdk-clb-connection-draining/typescript-cdk-clb-connection-draining_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-clb-connection-draining/typescript-cdk-clb-connection-draining_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-clb-connection-draining@v1.0 defects=0}
+import {
+  CfnLoadBalancer
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables connection draining for graceful termination.
+    new CfnLoadBalancer(Stack, 'rCfnElb', {
+      listeners: [
+        { instancePort: '42', loadBalancerPort: '42', protocol: 'TCP' }
+      ],
+      connectionDrainingPolicy: { enabled: true }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-clb-connection-draining/typescript-cdk-clb-connection-draining_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-clb-connection-draining/typescript-cdk-clb-connection-draining_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-clb-connection-draining@v1.0 defects=1}
+import {
+  CfnLoadBalancer
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables connection draining, risking abrupt connection termination.
+    new CfnLoadBalancer(Stack, 'rCfnElb', {
+      listeners: [
+        { instancePort: '42', loadBalancerPort: '42', protocol: 'TCP' }
+      ],
+      connectionDrainingPolicy: { enabled: false }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-clb-no-inbound-http-https/typescript-cdk-clb-no-inbound-http-https_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-clb-no-inbound-http-https/typescript-cdk-clb-no-inbound-http-https_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-clb-no-inbound-http-https@v1.0 defects=0}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  LoadBalancer,
+  LoadBalancingProtocol,
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: The LoadBalancer uses SSL on port 42, ensuring secure communication.
+    const elb2 = new LoadBalancer(Stack, 'rELB', {
+        vpc: new Vpc(Stack, 'rVPC')
+    });
+    elb2.addListener({
+      externalPort: 42,
+      externalProtocol: LoadBalancingProtocol.SSL
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-clb-no-inbound-http-https/typescript-cdk-clb-no-inbound-http-https_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-clb-no-inbound-http-https/typescript-cdk-clb-no-inbound-http-https_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-clb-no-inbound-http-https@v1.0 defects=1}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  LoadBalancer
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: The LoadBalancer uses HTTP on port 80, which is insecure.
+    const elb = new LoadBalancer(Stack, 'rELB', {
+      vpc: new Vpc(Stack, 'rVPC'),
+    });
+    elb.addListener({ externalPort: 80 });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cloud-front-distribution-no-outdated-ssl/typescript-cdk-cloud-front-distribution-no-outdated-ssl_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cloud-front-distribution-no-outdated-ssl/typescript-cdk-cloud-front-distribution-no-outdated-ssl_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cloud-front-distribution-no-outdated-ssl@v1.0 defects=0}
+import {
+  Distribution,
+  OriginSslPolicy } from 'aws-cdk-lib/aws-cloudfront';
+import { HttpOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses TLS 1.2, ensuring stronger encryption and security.
+    new Distribution(Stack, 'rDistribution2', {
+      defaultBehavior: {
+        origin: new HttpOrigin('foo.bar.com', {
+          originSslProtocols: [OriginSslPolicy.TLS_V1_2]
+        })
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cloud-front-distribution-no-outdated-ssl/typescript-cdk-cloud-front-distribution-no-outdated-ssl_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cloud-front-distribution-no-outdated-ssl/typescript-cdk-cloud-front-distribution-no-outdated-ssl_non-compliant.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cloud-front-distribution-no-outdated-ssl@v1.0 defects=1}
+import {
+  Distribution,
+  OriginSslPolicy } from 'aws-cdk-lib/aws-cloudfront';
+import { HttpOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses TLS 1.0 and 1.1, which are outdated and less secure.
+    new Distribution(Stack, 'rDistribution', {
+      defaultBehavior: {
+        origin: new HttpOrigin('foo.bar.com', {
+          originSslProtocols: [
+            OriginSslPolicy.TLS_V1,
+            OriginSslPolicy.TLS_V1_1
+          ]
+        })
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-strong-password-policy/typescript-cdk-cognito-user-pool-strong-password-policy_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-strong-password-policy/typescript-cdk-cognito-user-pool-strong-password-policy_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cognito-user-pool-strong-password-policy@v1.0 defects=0}
+import { UserPool } from 'aws-cdk-lib/aws-cognito';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enforces a strong password policy with complexity requirements.
+    new UserPool(Stack, 'rUserPool', {
+      passwordPolicy: {
+        minLength: 8,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-strong-password-policy/typescript-cdk-cognito-user-pool-strong-password-policy_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-cognito-user-pool-strong-password-policy/typescript-cdk-cognito-user-pool-strong-password-policy_non-compliant.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-cognito-user-pool-strong-password-policy@v1.0 defects=1}
+import { UserPool } from 'aws-cdk-lib/aws-cognito';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Lacks a password policy, potentially allowing weak passwords.
+    new UserPool(Stack, 'rUserPool');
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-backup-retention-period/typescript-cdk-document-db-cluster-backup-retention-period_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-backup-retention-period/typescript-cdk-document-db-cluster-backup-retention-period_compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-backup-retention-period@v1.0 defects=0}
+import { DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import {  Duration, SecretValue, Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+    // Compliant: Configures backup retention for 7 days, ensuring data recovery.
+    new DatabaseCluster(Stack, 'rDatabaseCluster', {
+      instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+      vpc: new Vpc(Stack, 'rVpc'),
+      backup: { retention: Duration.days(7) },
+      masterUser: {
+        username: SecretValue.secretsManager('foo').toString(),
+        password: SecretValue.secretsManager('bar')
+      }
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-backup-retention-period/typescript-cdk-document-db-cluster-backup-retention-period_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-document-db-cluster-backup-retention-period/typescript-cdk-document-db-cluster-backup-retention-period_non-compliant.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-document-db-cluster-backup-retention-period@v1.0 defects=1}
+import { DatabaseCluster } from 'aws-cdk-lib/aws-docdb';
+import {
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import { SecretValue, Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+    // Noncompliant: Lacks backup retention configuration, risking potential data loss.
+    new DatabaseCluster(Stack, 'rDatabaseCluster', {
+      instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
+      vpc: new Vpc(Stack, 'rVpc'),
+      masterUser: {
+        username: SecretValue.secretsManager('foo').toString(),
+        password: SecretValue.secretsManager('bar')
+      }
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec-2-instance-detailed-monitoring-enabled/typescript-cdk-ec-2-instance-detailed-monitoring-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec-2-instance-detailed-monitoring-enabled/typescript-cdk-ec-2-instance-detailed-monitoring-enabled_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec-2-instance-detailed-monitoring-enabled@v1.0 defects=0}
+import {
+  Instance,
+  InstanceClass,
+  InstanceType,
+  MachineImage,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables detailed monitoring, providing enhanced performance metrics.
+    new Instance(Stack, 'rInstance', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      instanceType: new InstanceType(InstanceClass.T3),
+      machineImage: MachineImage.latestAmazonLinux2()
+    }).instance.monitoring = true;
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec-2-instance-detailed-monitoring-enabled/typescript-cdk-ec-2-instance-detailed-monitoring-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec-2-instance-detailed-monitoring-enabled/typescript-cdk-ec-2-instance-detailed-monitoring-enabled_non-compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec-2-instance-detailed-monitoring-enabled@v1.0 defects=1}
+import {
+  Instance,
+  InstanceClass,
+  InstanceType,
+  MachineImage,
+  Vpc
+  } from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not enable detailed monitoring, limiting available metrics.
+    new Instance(Stack, 'rInstance', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      instanceType: new InstanceType(InstanceClass.T3),
+      machineImage: MachineImage.latestAmazonLinux2()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec-2-security-group-description/typescript-cdk-ec-2-security-group-description_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec-2-security-group-description/typescript-cdk-ec-2-security-group-description_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec-2-security-group-description@v1.0 defects=0}
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+import {
+  SecurityGroup,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);      
+    // Compliant: Provides a descriptive security group, improving clarity.
+    new SecurityGroup(Stack, 'rSg', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      description: 'lorem ipsum dolor sit amet'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec-2-security-group-description/typescript-cdk-ec-2-security-group-description_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec-2-security-group-description/typescript-cdk-ec-2-security-group-description_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec-2-security-group-description@v1.0 defects=1}
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+import {
+  SecurityGroup,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);      
+    // Noncompliant: Provides an empty description, making it harder to identify the security group’s purpose.
+    new SecurityGroup(Stack, 'rSg', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      description: ' '
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec2-instance-termination-protection/typescript-cdk-ec2-instance-termination-protection_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec2-instance-termination-protection/typescript-cdk-ec2-instance-termination-protection_compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec2-instance-termination-protection@v1.0 defects=0}
+import {
+  Instance,
+  InstanceClass,
+  InstanceType,
+  MachineImage,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Disables API termination, preventing accidental instance termination.
+    const instance = new Instance(Stack, 'rInstance', {
+      vpc: new Vpc(Stack, 'rVpc'),
+      instanceType: new InstanceType(InstanceClass.T3),
+      machineImage: MachineImage.latestAmazonLinux2()
+    });
+    instance.instance.disableApiTermination = true;
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-ec2-instance-termination-protection/typescript-cdk-ec2-instance-termination-protection_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-ec2-instance-termination-protection/typescript-cdk-ec2-instance-termination-protection_non-compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-ec2-instance-termination-protection@v1.0 defects=1}
+import {
+  Instance,
+  InstanceClass,
+  InstanceType,
+  MachineImage,
+  Vpc
+} from 'aws-cdk-lib/aws-ec2';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Allows API termination, increasing the risk of accidental instance deletion.
+    new Instance(Stack, 'rInstance', {vpc: new Vpc(Stack, 'rVpc'),
+      instanceType: new InstanceType(InstanceClass.T3),
+      machineImage: MachineImage.latestAmazonLinux2()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-eks-cluster-control-plane-logs/typescript-cdk-eks-cluster-control-plane-logs_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-eks-cluster-control-plane-logs/typescript-cdk-eks-cluster-control-plane-logs_compliant.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-eks-cluster-control-plane-logs@v1.0 defects=0}
+import {
+  Cluster,
+  ClusterLoggingTypes,
+  EndpointAccess,
+  KubernetesVersion
+} from 'aws-cdk-lib/aws-eks';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+    
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);      
+    // Compliant: Uses private endpoint access and enables comprehensive cluster logging for security and auditing.
+    new Cluster(Stack, 'rCustomEKS', {
+      version: KubernetesVersion.V1_14,
+      endpointAccess: EndpointAccess.PRIVATE,
+      clusterLogging: [
+        ClusterLoggingTypes.API,
+        ClusterLoggingTypes.AUDIT,
+        ClusterLoggingTypes.AUTHENTICATOR,
+        ClusterLoggingTypes.CONTROLLER_MANAGER,
+        ClusterLoggingTypes.SCHEDULER
+      ]
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-eks-cluster-control-plane-logs/typescript-cdk-eks-cluster-control-plane-logs_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-eks-cluster-control-plane-logs/typescript-cdk-eks-cluster-control-plane-logs_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-eks-cluster-control-plane-logs@v1.0 defects=1}
+import {
+    Cluster,
+    EndpointAccess,
+    KubernetesVersion,
+} from 'aws-cdk-lib/aws-eks';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+    
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);      
+    // Noncompliant: Uses public endpoint access, increasing exposure to potential security risks.
+    new Cluster(Stack, 'rCustomEKS', {
+      version: KubernetesVersion.V1_14,
+      endpointAccess: EndpointAccess.PUBLIC
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elastic-beanstalk-managed-updates-enabled/typescript-cdk-elastic-beanstalk-managed-updates-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elastic-beanstalk-managed-updates-enabled/typescript-cdk-elastic-beanstalk-managed-updates-enabled_compliant.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elastic-beanstalk-managed-updates-enabled@v1.0 defects=0}
+import { CfnEnvironment } from 'aws-cdk-lib/aws-elasticbeanstalk';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Specifies `UpdateLevel: minor`, ensuring only non-disruptive updates are applied to the environment.
+    new CfnEnvironment(Stack, 'rBeanstalk', {
+      applicationName: 'foo',
+      optionSettings: [
+        {
+          namespace: 'aws:elasticbeanstalk:managedactions',
+          optionName: 'ManagedActionsEnabled'
+        },
+        {
+          namespace: 'aws:elasticbeanstalk:managedactions',
+          optionName: 'PreferredStartTime',
+          value: 'Tue:09:00'
+        },
+        {
+          namespace: 'aws:elasticbeanstalk:managedactions:platformupdate',
+          optionName: 'UpdateLevel',
+          value: 'minor'
+        }
+      ]
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elastic-beanstalk-managed-updates-enabled/typescript-cdk-elastic-beanstalk-managed-updates-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elastic-beanstalk-managed-updates-enabled/typescript-cdk-elastic-beanstalk-managed-updates-enabled_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elastic-beanstalk-managed-updates-enabled@v1.0 defects=1}
+import { CfnEnvironment } from 'aws-cdk-lib/aws-elasticbeanstalk';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not specify `UpdateLevel`, potentially allowing disruptive updates that could affect application stability.
+    new CfnEnvironment(Stack, 'rBeanstalk', {
+      applicationName: 'foo'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elb-cross-zone-load-balancing-enabled/typescript-cdk-elb-cross-zone-load-balancing-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elb-cross-zone-load-balancing-enabled/typescript-cdk-elb-cross-zone-load-balancing-enabled_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elb-cross-zone-load-balancing-enabled@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  LoadBalancer
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables cross-zone load balancing for better fault tolerance.
+    new LoadBalancer(Stack, 'rELB', {
+        vpc: new Vpc(Stack, 'rVPC'),
+        crossZone: true
+    });
+ }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elb-cross-zone-load-balancing-enabled/typescript-cdk-elb-cross-zone-load-balancing-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elb-cross-zone-load-balancing-enabled/typescript-cdk-elb-cross-zone-load-balancing-enabled_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elb-cross-zone-load-balancing-enabled@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  LoadBalancer
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables cross-zone load balancing, reducing fault tolerance.
+    new LoadBalancer(Stack, 'rELB', {
+      vpc: new Vpc(Stack, 'rVPC'),
+      crossZone: false
+    });
+ }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elb-tls-https-listeners-only/typescript-cdk-elb-tls-https-listeners-only_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elb-tls-https-listeners-only/typescript-cdk-elb-tls-https-listeners-only_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elb-tls-https-listeners-only@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  LoadBalancer,
+  LoadBalancingProtocol
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses SSL for internal communication, ensuring encrypted traffic within the VPC.
+    new LoadBalancer(Stack, 'rELB1', {
+        vpc: new Vpc(Stack, 'rVPC'),
+      }).addListener({
+      internalProtocol: LoadBalancingProtocol.SSL,
+      externalPort: 42,
+      externalProtocol: LoadBalancingProtocol.SSL
+    });
+ }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-elb-tls-https-listeners-only/typescript-cdk-elb-tls-https-listeners-only_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-elb-tls-https-listeners-only/typescript-cdk-elb-tls-https-listeners-only_non-compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-elb-tls-https-listeners-only@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  LoadBalancer,
+  LoadBalancingProtocol
+} from 'aws-cdk-lib/aws-elasticloadbalancing';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses TCP for internal communication, exposing traffic unencrypted within the VPC.
+    new LoadBalancer(Stack, 'rELB', {
+        vpc: new Vpc(Stack, 'rVPC'),
+      }).addListener({
+      internalProtocol: LoadBalancingProtocol.TCP,
+      externalPort: 42,
+      externalProtocol: LoadBalancingProtocol.SSL
+    });
+ }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos_compliant.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos@v1.0 defects=0}
+import { CfnCluster} from 'aws-cdk-lib/aws-emr';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);   
+    // Compliant: Configures Kerberos authentication, enhancing security for the EMR cluster.
+    new CfnCluster(Stack, 'rEmrCluster', {
+      instances: {},
+      jobFlowRole: ' EMR_EC2_DefaultRole',
+      name: 'foo',
+      serviceRole: 'bar',
+      kerberosAttributes: {
+        kdcAdminPassword: 'baz',
+        realm: 'qux'
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos/typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-emr-auth-ec-2-key-pair-or-kerberos@v1.0 defects=1}
+import { CfnCluster} from 'aws-cdk-lib/aws-emr';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);   
+    // Noncompliant: Lacks Kerberos configuration, potentially exposing the cluster to security risks.
+    new CfnCluster(Stack, 'rEmrCluster', {
+      instances: {},
+      jobFlowRole: ' EMR_EC2_DefaultRole',
+      name: 'foo',
+      serviceRole: 'bar'
+    });
+  }
+}
+// {/fact}


### PR DESCRIPTION
Added non compliant and compliant samples for typescript cdk detectors.

Note: All the test cases  have 100 % recall and precision.