### PR TITLE
Added DL cases for typescript cdk

### DIFF
--- a/cdk_typescript/src/detectors/typescript-cdk-emrs-3-access-logging/typescript-cdk-emrs-3-access-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-emrs-3-access-logging/typescript-cdk-emrs-3-access-logging_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-emrs-3-access-logging@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-emr';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Specifies a `logUri`, enabling logging for the EMR cluster.
+    new CfnCluster(Stack, 'rEmrCluster', {
+      instances: {},
+      jobFlowRole: ' EMR_EC2_DefaultRole',
+      name: 'foo',
+      serviceRole: 'bar',
+      logUri: 'baz'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-emrs-3-access-logging/typescript-cdk-emrs-3-access-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-emrs-3-access-logging/typescript-cdk-emrs-3-access-logging_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-emrs-3-access-logging@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-emr';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Missing `logUri`, which prevents logging and makes it harder to monitor the cluster's activities.
+    new CfnCluster(Stack, 'rEmrCluster', {
+      instances: {},
+      jobFlowRole: ' EMR_EC2_DefaultRole',
+      name: 'foo',
+      serviceRole: 'bar'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-iam-no-managed-policies/typescript-cdk-iam-no-managed-policies_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-iam-no-managed-policies/typescript-cdk-iam-no-managed-policies_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-iam-no-managed-policies@v1.0 defects=0}
+import {
+  ManagedPolicy,
+  Role,
+  AccountRootPrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses a restrictive managed policy.
+    new Role(Stack, 'rRole', {
+      assumedBy: new AccountRootPrincipal(),
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('NotSoPermissivePolicy')]
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-iam-no-managed-policies/typescript-cdk-iam-no-managed-policies_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-iam-no-managed-policies/typescript-cdk-iam-no-managed-policies_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-iam-no-managed-policies@v1.0 defects=1}
+import {
+  ManagedPolicy,
+  Role,
+  AccountRootPrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses `AdministratorAccess`, a very permissive policy that grants excessive permissions.
+    new Role(Stack, 'rRole', {
+      assumedBy: new AccountRootPrincipal(),
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('AdministratorAccess')]
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-mks-client-to-broker-tls/typescript-cdk-mks-client-to-broker-tls_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-mks-client-to-broker-tls/typescript-cdk-mks-client-to-broker-tls_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-mks-client-to-broker-tls@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-msk';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses `TLS` for encryption in transit, ensuring secure communication.
+    new CfnCluster(Stack, 'rMsk', {
+      clusterName: 'foo',
+      kafkaVersion: '2.8.0',
+      brokerNodeGroupInfo: {
+        clientSubnets: ['bar'],
+        instanceType: 'kafka.m5.large',
+      },
+      numberOfBrokerNodes: 42,
+      encryptionInfo: { encryptionInTransit: { clientBroker: 'TLS' } }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-mks-client-to-broker-tls/typescript-cdk-mks-client-to-broker-tls_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-mks-client-to-broker-tls/typescript-cdk-mks-client-to-broker-tls_non-compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-mks-client-to-broker-tls@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-msk';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses `TLS_PLAINTEXT`, which allows unencrypted communication and reduces security.
+    new CfnCluster(Stack, 'rMsk', {
+      clusterName: 'foo',
+      kafkaVersion: '2.8.0',
+      brokerNodeGroupInfo: {
+        clientSubnets: ['bar'],
+        instanceType: 'kafka.m5.large',
+      },
+      numberOfBrokerNodes: 42,
+      encryptionInfo: {
+        encryptionInTransit: { clientBroker: 'TLS_PLAINTEXT' }
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-msk-broker-logging/typescript-cdk-msk-broker-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-msk-broker-logging/typescript-cdk-msk-broker-logging_compliant.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-msk-broker-logging@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-msk';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Configures logging to S3 and CloudWatch, ensuring proper monitoring and auditing.
+    new CfnCluster(Stack, 'rMsk', {
+      clusterName: 'foo',
+      kafkaVersion: '2.8.0',
+      brokerNodeGroupInfo: {
+        clientSubnets: ['bar'],
+        instanceType: 'kafka.m5.large',
+      },
+      numberOfBrokerNodes: 42,
+      loggingInfo: {
+        brokerLogs: {
+          s3: { enabled: true, bucket: 'foo' },
+          cloudWatchLogs: { enabled: true, logGroup: 'baz' }
+        }
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-msk-broker-logging/typescript-cdk-msk-broker-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-msk-broker-logging/typescript-cdk-msk-broker-logging_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-msk-broker-logging@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-msk';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Lacks logging configuration, making it harder to monitor and audit the cluster’s activities.
+    new CfnCluster(Stack, 'rMsk', {
+      clusterName: 'foo',
+      kafkaVersion: '2.8.0',
+      brokerNodeGroupInfo: {
+        clientSubnets: ['bar'],
+        instanceType: 'kafka.m5.large',
+      },
+      numberOfBrokerNodes: 42
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-msk-broker-to-broker-tls/typescript-cdk-msk-broker-to-broker-tls_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-msk-broker-to-broker-tls/typescript-cdk-msk-broker-to-broker-tls_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-msk-broker-to-broker-tls@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-msk';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);     
+    // Compliant: Enables `inCluster` encryption in transit, ensuring secure communication within the Kafka cluster.
+    new CfnCluster(Stack, 'rMsk', {
+      clusterName: 'foo',
+      kafkaVersion: '2.8.0',
+      brokerNodeGroupInfo: {
+        clientSubnets: ['bar'],
+        instanceType: 'kafka.m5.large'
+      },
+      numberOfBrokerNodes: 42,
+      encryptionInfo: { encryptionInTransit: { inCluster: true } }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-msk-broker-to-broker-tls/typescript-cdk-msk-broker-to-broker-tls_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-msk-broker-to-broker-tls/typescript-cdk-msk-broker-to-broker-tls_non-compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-msk-broker-to-broker-tls@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-msk';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);     
+    // Noncompliant: Disables inCluster encryption, potentially exposing data to security risks within the cluster.
+    new CfnCluster(Stack, 'rMsk', {
+      clusterName: 'foo',
+      kafkaVersion: '2.8.0',
+      brokerNodeGroupInfo: {
+        clientSubnets: ['bar'],
+        instanceType: 'kafka.m5.large'
+      },
+      numberOfBrokerNodes: 42,
+      encryptionInfo: { encryptionInTransit: { inCluster: false } }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade_compliant.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-automatic-minor-version-upgrade@v1.0 defects=0}
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+import { CfnDBInstance } from 'aws-cdk-lib/aws-neptune';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+	super(scope, id, props);      
+    // Compliant: Enables automatic minor version upgrades, ensuring the database is up to date.
+    new CfnDBInstance(Stack, 'rDatabaseInstance', {
+      dbInstanceClass: 'db.r4.2xlarge',
+      autoMinorVersionUpgrade: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade/typescript-cdk-neptune-cluster-automatic-minor-version-upgrade_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-automatic-minor-version-upgrade@v1.0 defects=1}
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+import { CfnDBInstance } from 'aws-cdk-lib/aws-neptune';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);      
+    // Noncompliant: Does not enable automatic minor version upgrades, risking outdated database versions.
+    new CfnDBInstance(Stack, 'rDatabaseInstance', {
+      dbInstanceClass: 'db.r4.2xlarge'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-backup-retention-period/typescript-cdk-neptune-cluster-backup-retention-period_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-backup-retention-period/typescript-cdk-neptune-cluster-backup-retention-period_compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-backup-retention-period@v1.0 defects=0}
+import { CfnDBCluster } from 'aws-cdk-lib/aws-neptune';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Sets `backupRetentionPeriod` to 7 days, ensuring backups are retained for recovery.
+    new CfnDBCluster(Stack, 'rDatabaseCluster', {
+      backupRetentionPeriod: 7
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-backup-retention-period/typescript-cdk-neptune-cluster-backup-retention-period_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-backup-retention-period/typescript-cdk-neptune-cluster-backup-retention-period_non-compliant.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-backup-retention-period@v1.0 defects=1}
+import { CfnDBCluster } from 'aws-cdk-lib/aws-neptune';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not specify `backupRetentionPeriod`, potentially leading to insufficient backup retention
+    new CfnDBCluster(Stack, 'rDatabaseCluster');
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-multi-az/typescript-cdk-neptune-cluster-multi-az_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-multi-az/typescript-cdk-neptune-cluster-multi-az_compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-multi-az@v1.0 defects=0}
+import {DatabaseInstance} from 'aws-cdk-lib/aws_rds';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    // Compliant: Enables `multiAz`, ensuring high availability and fault tolerance for the database.
+    new DatabaseInstance(Stack, 'rDatabaseCluster', {
+      multiAz: true
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-multi-az/typescript-cdk-neptune-cluster-multi-az_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-multi-az/typescript-cdk-neptune-cluster-multi-az_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-multi-az@v1.0 defects=1}
+import {DatabaseInstance} from 'aws-cdk-lib/aws_rds';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    // Noncompliant: Disables `multiAz`, risking single points of failure and reduced availability.
+    new DatabaseInstance(Stack, 'rDatabaseCluster', {
+      multiAz: false
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-allowlisted-ips/typescript-cdk-open-search-allowlisted-ips_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-allowlisted-ips/typescript-cdk-open-search-allowlisted-ips_compliant.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-allowlisted-ips@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import {
+  CfnDomain as LegacyCfnDomain,
+  ElasticsearchVersion,
+} from 'aws-cdk-lib/aws-elasticsearch';
+import {
+  AccountRootPrincipal,
+  Effect,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+} from 'aws-cdk-lib/aws-iam';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Specifies an `IpAddress` condition for access, restricting access to a specific IP address for added security.
+    new LegacyCfnDomain(Stack, 'Domain', {
+      elasticsearchVersion: ElasticsearchVersion.V7_10.version,
+      accessPolicies: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+            effect: Effect.ALLOW,
+            principals: [
+              new Role(Stack, 'Role', {
+                assumedBy: new AccountRootPrincipal(),
+              }),
+            ],
+            resources: ['*'],
+            conditions: {
+              IpAddress: {
+                'aws:sourceIp': ['42.42.42.42']
+              }
+            }
+          })
+        ]
+      }).toJSON()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-allowlisted-ips/typescript-cdk-open-search-allowlisted-ips_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-allowlisted-ips/typescript-cdk-open-search-allowlisted-ips_non-compliant.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-allowlisted-ips@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import {
+  CfnDomain as LegacyCfnDomain,
+  ElasticsearchVersion
+} from 'aws-cdk-lib/aws-elasticsearch';
+import {
+  AccountRootPrincipal,
+  Effect,
+  PolicyDocument,
+  PolicyStatement,
+  Role
+} from 'aws-cdk-lib/aws-iam';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not include an `IpAddress` condition, allowing broader access and potentially exposing the domain to unauthorized access.
+    new LegacyCfnDomain(Stack, 'Domain', {
+      elasticsearchVersion: ElasticsearchVersion.V7_10.version,
+      accessPolicies: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+            effect: Effect.ALLOW,
+            principals: [
+              new Role(Stack, 'Role', {
+                assumedBy: new AccountRootPrincipal()
+              })
+            ],
+            resources: ['*']
+          })
+        ]
+      }).toJSON()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-dedicated-master-node/typescript-cdk-open-search-dedicated-master-node_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-dedicated-master-node/typescript-cdk-open-search-dedicated-master-node_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-dedicated-master-node@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import {
+  Domain as LegacyDomain,
+  ElasticsearchVersion
+} from 'aws-cdk-lib/aws-elasticsearch';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Specifies`masterNodes` capacity, ensuring sufficient resources for the Elasticsearch cluster.
+    new LegacyDomain(Stack, 'Domain', {
+      version: ElasticsearchVersion.V7_10,
+      capacity: { masterNodes: 42 }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-dedicated-master-node/typescript-cdk-open-search-dedicated-master-node_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-dedicated-master-node/typescript-cdk-open-search-dedicated-master-node_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-dedicated-master-node@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import {
+  Domain as LegacyDomain,
+  ElasticsearchVersion,
+} from 'aws-cdk-lib/aws-elasticsearch';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not specify `masterNodes`, potentially leading to insufficient capacity for the Elasticsearch cluster.
+    new LegacyDomain(Stack, 'Domain', {
+      version: ElasticsearchVersion.V7_10
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-no-unsigned-or-anonymous-access/typescript-cdk-open-search-no-unsigned-or-anonymous-access_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-no-unsigned-or-anonymous-access/typescript-cdk-open-search-no-unsigned-or-anonymous-access_compliant.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-no-unsigned-or-anonymous-access@v1.0 defects=0}
+import {
+  CfnDomain as LegacyCfnDomain,
+  ElasticsearchVersion
+} from 'aws-cdk-lib/aws-elasticsearch';
+import {
+  AccountRootPrincipal,
+  Effect,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+} from 'aws-cdk-lib/aws-iam';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Includes an `IpAddress` condition, restricting access to a specific IP address for better security.
+    new LegacyCfnDomain(Stack, 'Domain', {
+      elasticsearchVersion: ElasticsearchVersion.V7_10.version,
+      accessPolicies: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+            effect: Effect.ALLOW,
+            principals: [
+              new Role(Stack, 'Role', {
+                assumedBy: new AccountRootPrincipal(),
+              }),
+            ],
+            resources: ['*'],
+            conditions: {
+              IpAddress: {
+                'aws:sourceIp': ['42.42.42.42']
+              }
+            }
+          })
+        ]
+      }).toJSON()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-no-unsigned-or-anonymous-access/typescript-cdk-open-search-no-unsigned-or-anonymous-access_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-no-unsigned-or-anonymous-access/typescript-cdk-open-search-no-unsigned-or-anonymous-access_non-compliant.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-no-unsigned-or-anonymous-access@v1.0 defects=1}
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  CfnDomain as LegacyCfnDomain,
+  ElasticsearchVersion
+} from 'aws-cdk-lib/aws-elasticsearch';
+import {
+  AnyPrincipal,
+  Effect,
+  PolicyDocument,
+  PolicyStatement
+} from 'aws-cdk-lib/aws-iam';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Uses `AnyPrincipal()` with no access restrictions, potentially allowing unrestricted access to the Elasticsearch domain.
+    new LegacyCfnDomain(Stack, 'Domain', {
+      elasticsearchVersion: ElasticsearchVersion.V7_10.version,
+      accessPolicies: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+            effect: Effect.ALLOW,
+            principals: [new AnyPrincipal()],
+            resources: ['*']
+        })
+        ]
+      }).toJSON()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-slow-logs-to-cloud-watch/typescript-cdk-open-search-slow-logs-to-cloud-watch_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-slow-logs-to-cloud-watch/typescript-cdk-open-search-slow-logs-to-cloud-watch_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-slow-logs-to-cloud-watch@v1.0 defects=0}
+import {
+Domain as LegacyDomain,
+ElasticsearchVersion,
+} from 'aws-cdk-lib/aws-elasticsearch';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);   
+    // Compliant: Enables logging for better monitoring.
+    new LegacyDomain(Stack, 'Domain', {
+      version: ElasticsearchVersion.V7_10,
+      logging: { slowIndexLogEnabled: true, slowSearchLogEnabled: true }
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-slow-logs-to-cloud-watch/typescript-cdk-open-search-slow-logs-to-cloud-watch_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-slow-logs-to-cloud-watch/typescript-cdk-open-search-slow-logs-to-cloud-watch_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-slow-logs-to-cloud-watch@v1.0 defects=1}
+import {
+Domain as LegacyDomain,
+ElasticsearchVersion
+} from 'aws-cdk-lib/aws-elasticsearch';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);   
+    // Noncompliant: Disables logging, reducing visibility.
+    new LegacyDomain(Stack, 'Domain', {
+      version: ElasticsearchVersion.V7_10
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-zone-awareness/typescript-cdk-open-search-zone-awareness_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-zone-awareness/typescript-cdk-open-search-zone-awareness_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-zone-awareness@v1.0 defects=0}
+import {
+    Domain as LegacyDomain,
+    ElasticsearchVersion,
+} from 'aws-cdk-lib/aws-elasticsearch';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables `zoneAwareness` for high availability and fault tolerance.
+    new LegacyDomain(Stack, 'Domain', {
+      version: ElasticsearchVersion.V7_10,
+      capacity: { masterNodes: 42 },
+      zoneAwareness: { enabled: true }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-zone-awareness/typescript-cdk-open-search-zone-awareness_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-zone-awareness/typescript-cdk-open-search-zone-awareness_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-zone-awareness@v1.0 defects=1}
+import {
+    Domain as LegacyDomain,
+    ElasticsearchVersion,
+} from 'aws-cdk-lib/aws-elasticsearch';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not enable `zoneAwareness`, risking lower availability and resilience.
+    new LegacyDomain(Stack, 'Domain', {
+      version: ElasticsearchVersion.V7_10
+    });
+  }
+}
+// {/fact}


### PR DESCRIPTION
Added non compliant and compliant samples for typescript cdk detectors.


Note: All the test cases  have 100 % recall and precision.


