### PR TITLE
Added DL cases for typescript cdk

### DIFF
--- a/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-scaling-notifications/typescript-cdk-auto-scaling-group-scaling-notifications_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-scaling-notifications/typescript-cdk-auto-scaling-group-scaling-notifications_compliant.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-auto-scaling-group-scaling-notifications@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AutoScalingGroup,
+  ScalingEvent,
+  ScalingEvents
+} from 'aws-cdk-lib/aws-autoscaling';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import {
+  InstanceClass,
+  InstanceType,
+  MachineImage
+} from 'aws-cdk-lib/aws-ec2';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Configures notifications for all scaling events, ensuring full visibility.
+    const negTopic = new Topic(Stack, 'rAsgTopic');
+      new AutoScalingGroup(Stack, 'rAsg', {
+        vpc: new Vpc(Stack, 'rVpc'),
+        instanceType: new InstanceType(InstanceClass.T3),
+        machineImage: MachineImage.latestAmazonLinux(),
+        notifications: [
+          {
+            scalingEvents: {
+              _types: [
+                ScalingEvent.INSTANCE_TERMINATE,
+                ScalingEvent.INSTANCE_TERMINATE_ERROR
+              ]
+            },
+            topic: negTopic,
+          },
+          {
+            scalingEvents: ScalingEvents.LAUNCH_EVENTS,
+            topic: negTopic
+          }
+        ]
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-scaling-notifications/typescript-cdk-auto-scaling-group-scaling-notifications_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-auto-scaling-group-scaling-notifications/typescript-cdk-auto-scaling-group-scaling-notifications_non-compliant.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-auto-scaling-group-scaling-notifications@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  AutoScalingGroup,
+  ScalingEvents
+} from 'aws-cdk-lib/aws-autoscaling';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import {
+  InstanceClass,
+  InstanceType,
+  MachineImage
+} from 'aws-cdk-lib/aws-ec2';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Only configures error events, limiting notification coverage.
+    new AutoScalingGroup(Stack, 'rAsg', {
+        vpc: new Vpc(Stack, 'rVpc'),
+        instanceType: new InstanceType(InstanceClass.T3),
+        machineImage: MachineImage.latestAmazonLinux(),
+        notifications: [
+          {
+            scalingEvents: ScalingEvents.ERRORS,
+            topic: new Topic(Stack, 'rAsgTopic')
+          }
+        ]
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aws-cdk-no-region-in-global-resources-check/typescript-cdk-aws-cdk-no-region-in-global-resources-check_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aws-cdk-no-region-in-global-resources-check/typescript-cdk-aws-cdk-no-region-in-global-resources-check_compliant.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-encryption-at-rest@v1.0 defects=0}
+import * as s3 from 'monocdk/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: An S3 bucket with a region-specific name (us-east-1).
+    const goodBucket = new s3.Bucket(this, 's3-bucket-good-us-east-1')
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-aws-cdk-no-region-in-global-resources-check/typescript-cdk-aws-cdk-no-region-in-global-resources-check_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-aws-cdk-no-region-in-global-resources-check/typescript-cdk-aws-cdk-no-region-in-global-resources-check_non-compliant.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-encryption-at-rest@v1.0 defects=1}
+import * as s3 from 'monocdk/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: A bucket without specifying a region in the global resource name, which could lead to naming conflicts across regions.
+    const badBucket = new s3.Bucket(this, 's3-bucket-bad', {bucketName: 's3-bucket'})
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-encryption-at-rest/typescript-cdk-neptune-cluster-encryption-at-rest_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-encryption-at-rest/typescript-cdk-neptune-cluster-encryption-at-rest_compliant.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-encryption-at-rest@v1.0 defects=0}
+import { CfnDBCluster } from 'aws-cdk-lib/aws-neptune';
+import { Stack } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables storage encryption for data security.
+    new CfnDBCluster(Stack, 'rDatabaseCluster', { storageEncrypted: true });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-encryption-at-rest/typescript-cdk-neptune-cluster-encryption-at-rest_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-neptune-cluster-encryption-at-rest/typescript-cdk-neptune-cluster-encryption-at-rest_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-neptune-cluster-encryption-at-rest@v1.0 defects=1}
+import { CfnDBCluster } from 'aws-cdk-lib/aws-neptune';
+import { Stack } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables storage encryption, compromising data security.
+    new CfnDBCluster(Stack, 'rDatabaseCluster', {
+      storageEncrypted: false
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-encrypted-at-rest/typescript-cdk-open-search-encrypted-at-rest_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-encrypted-at-rest/typescript-cdk-open-search-encrypted-at-rest_compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-encrypted-at-rest@v1.0 defects=0}
+import {
+  CfnDomain
+} from 'aws-cdk-lib/aws-opensearchservice';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables encryption at rest for data security.
+    new CfnDomain(Stack, 'Domain2', {
+      encryptionAtRestOptions: {
+        enabled: true
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-open-search-encrypted-at-rest/typescript-cdk-open-search-encrypted-at-rest_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-open-search-encrypted-at-rest/typescript-cdk-open-search-encrypted-at-rest_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-open-search-encrypted-at-rest@v1.0 defects=1}
+import {
+  CfnDomain
+} from 'aws-cdk-lib/aws-opensearchservice';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables encryption at rest, compromising data security.
+    new CfnDomain(Stack, 'Domain', {
+      encryptionAtRestOptions: {
+        enabled: false
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-quicksight-ssl-connections/typescript-cdk-quicksight-ssl-connections_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-quicksight-ssl-connections/typescript-cdk-quicksight-ssl-connections_compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-quicksight-ssl-connections@v1.0 defects=0}
+import { CfnDataSource } from 'aws-cdk-lib/aws-quicksight';
+import * as cdk from 'aws-cdk-lib';   
+import { Stack } from 'aws-cdk-lib';
+    
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);    
+    // Compliant: SSL enabled protects data in transit.
+    new CfnDataSource(Stack, 'rDashboard', {
+      sslProperties: { disableSsl: false }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-quicksight-ssl-connections/typescript-cdk-quicksight-ssl-connections_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-quicksight-ssl-connections/typescript-cdk-quicksight-ssl-connections_non-compliant.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-quicksight-ssl-connections@v1.0 defects=1}
+import { CfnDataSource } from 'aws-cdk-lib/aws-quicksight';
+import * as cdk from 'aws-cdk-lib';  
+import { Stack } from 'aws-cdk-lib';
+    
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);    
+    // Noncompliant: SSL disabled exposes data to security risks.
+    new CfnDataSource(Stack, 'rDashboard', {
+      sslProperties: { disableSsl: true }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-instance-backup-enabled/typescript-cdk-rds-instance-backup-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-instance-backup-enabled/typescript-cdk-rds-instance-backup-enabled_compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-instance-backup-enabled@v1.0 defects=0}
+import {
+CfnDBInstance
+} from 'aws-cdk-lib/aws-rds';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+    // Compliant: Backups enabled (15 days).
+    new CfnDBInstance(Stack, 'rDbInstance2', {
+      dbInstanceClass: 'db.t3.micro',
+      backupRetentionPeriod: 15
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-instance-backup-enabled/typescript-cdk-rds-instance-backup-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-instance-backup-enabled/typescript-cdk-rds-instance-backup-enabled_non-compliant.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-instance-backup-enabled@v1.0 defects=1}
+import {
+CfnDBInstance
+} from 'aws-cdk-lib/aws-rds';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+    // Noncompliant: Backups disabled (0 days).
+    new CfnDBInstance(Stack, 'rDbInstance', {
+      dbInstanceClass: 'db.t3.micro',
+      backupRetentionPeriod: 0
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-missing-storage-encryption/typescript-cdk-rds-missing-storage-encryption_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-missing-storage-encryption/typescript-cdk-rds-missing-storage-encryption_compliant.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-missing-storage-encryption@v1.0 defects=0}
+import * as cdk from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  PostgresEngineVersion
+} from 'aws-cdk-lib/aws-rds';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables storage encryption for data security.
+    const vpc = new Vpc(Stack, 'rVpc');
+    new DatabaseInstance(Stack, 'rDbInstance', {
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_13_2,
+      }),
+      vpc: vpc,
+      storageEncrypted: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-missing-storage-encryption/typescript-cdk-rds-missing-storage-encryption_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-missing-storage-encryption/typescript-cdk-rds-missing-storage-encryption_non-compliant.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-missing-storage-encryption@v1.0 defects=1}
+import * as cdk from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  PostgresEngineVersion
+} from 'aws-cdk-lib/aws-rds';
+import { Stack } from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables storage encryption, compromising data security.
+    new DatabaseInstance(Stack, 'rDbInstance', {
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_13_2,
+      }),
+      vpc: new Vpc(Stack, 'rVpc'),
+      storageEncrypted: false
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-multiaz-support-enabled/typescript-cdk-rds-multiaz-support-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-multiaz-support-enabled/typescript-cdk-rds-multiaz-support-enabled_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-multiaz-support-enabled@v1.0 defects=0}
+import {
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  PostgresEngineVersion
+} from "aws-cdk-lib/aws-rds";
+import { Stack } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables Multi-AZ deployment for high availability and fault tolerance.
+    new DatabaseInstance(Stack, "rDbInstance", {
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_13_2,
+      }),
+      multiAz: true
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-rds-multiaz-support-enabled/typescript-cdk-rds-multiaz-support-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-rds-multiaz-support-enabled/typescript-cdk-rds-multiaz-support-enabled_non-compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-rds-multiaz-support-enabled@v1.0 defects=1}
+import {
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  PostgresEngineVersion
+} from "aws-cdk-lib/aws-rds";
+import { Stack } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Disables Multi-AZ, reducing availability and fault tolerance.
+    new DatabaseInstance(Stack, "rDbInstance", {
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_13_2,
+      }),
+      multiAz: false
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-backup-enabled/typescript-cdk-redshift-backup-enabled_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-backup-enabled/typescript-cdk-redshift-backup-enabled_compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-backup-enabled@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    // Compliant: Automated snapshots enabled with retention period ≥ 1.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      automatedSnapshotRetentionPeriod: 1,
+      encrypted: true,
+      port:42
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-backup-enabled/typescript-cdk-redshift-backup-enabled_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-backup-enabled/typescript-cdk-redshift-backup-enabled_non-compliant.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-backup-enabled@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+	constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);      
+    // Noncompliant: Automated snapshots disabled with retention period = 0.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      automatedSnapshotRetentionPeriod: 0,
+      encrypted: true,
+      port:42
+    });
+	}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-audit-logging/typescript-cdk-redshift-cluster-audit-logging_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-audit-logging/typescript-cdk-redshift-cluster-audit-logging_compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-audit-logging@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Enables logging by specifying `loggingProperties`, aiding in auditing and monitoring.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      loggingProperties: { bucketName: 'foo' }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-audit-logging/typescript-cdk-redshift-cluster-audit-logging_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-audit-logging/typescript-cdk-redshift-cluster-audit-logging_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-audit-logging@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Omits logging configuration, reducing visibility and auditability of the cluster.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-maintenance-settings/typescript-cdk-redshift-cluster-maintenance-settings_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-maintenance-settings/typescript-cdk-redshift-cluster-maintenance-settings_compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-maintenance-settings@v1.0 defects=0}
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);      
+    // Compliant: `allowVersionUpgrade: true` enables automatic version upgrades for security and feature updates.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      allowVersionUpgrade: true,
+      preferredMaintenanceWindow: 'Sun:23:45-Mon:00:15'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-maintenance-settings/typescript-cdk-redshift-cluster-maintenance-settings_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-cluster-maintenance-settings/typescript-cdk-redshift-cluster-maintenance-settings_non-compliant.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-cluster-maintenance-settings@v1.0 defects=1}
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);      
+    // Noncompliant: `allowVersionUpgrade: false` disables automatic version upgrades, preventing important updates.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      allowVersionUpgrade: false,
+      preferredMaintenanceWindow: 'Sun:23:45-Mon:00:15'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-require-tls-ssl/typescript-cdk-redshift-require-tls-ssl_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-require-tls-ssl/typescript-cdk-redshift-require-tls-ssl_compliant.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-require-tls-ssl@v1.0 defects=0}
+import { CfnCluster, CfnClusterParameterGroup } from 'aws-cdk-lib/aws-redshift';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib/core";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Parameter group configured with `require_ssl: true` enforces SSL/TLS encrypted connections.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge',
+      clusterParameterGroupName: new CfnClusterParameterGroup(
+        Stack,
+        'rRedshiftParamGroup',
+        {
+          description: 'Cluster parameter group for family redshift-1.0',
+          parameterGroupFamily: 'redshift-1.0',
+          parameters: [
+            {
+              parameterName: 'require_ssl',
+              parameterValue: 'true'
+            }
+          ]
+        }
+      ).ref
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-redshift-require-tls-ssl/typescript-cdk-redshift-require-tls-ssl_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-redshift-require-tls-ssl/typescript-cdk-redshift-require-tls-ssl_non-compliant.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-redshift-require-tls-ssl@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import * as cdk from 'aws-cdk-lib';
+import { Stack } from "aws-cdk-lib";
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: No parameter group specified, allowing unencrypted connections by default.
+    new CfnCluster(Stack, 'rRedshiftCluster', {
+      masterUsername: 'use_a_secret_here',
+      masterUserPassword: 'use_a_secret_here',
+      clusterType: 'single-node',
+      dbName: 'bar',
+      nodeType: 'ds2.xlarge'
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities_compliant.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities@v1.0 defects=0}
+import { Stack } from 'aws-cdk-lib';
+import { OriginAccessIdentity } from 'aws-cdk-lib/aws-cloudfront';
+import {
+  Effect,
+  PolicyDocument,
+  PolicyStatement
+} from 'aws-cdk-lib/aws-iam';
+import {
+  Bucket,
+  CfnBucket,
+  CfnBucketPolicy,
+} from 'aws-cdk-lib/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Uses `OriginAccessIdentity` to restrict bucket access to CloudFront.
+    new Bucket(Stack, 'rBucket');
+    new CfnBucket(Stack, 'rBucket2', {
+      bucketName: 'foo',
+      websiteConfiguration: {
+        indexDocument: 'index.html',
+        errorDocument: 'error.html'
+      }
+    });
+    new CfnBucketPolicy(Stack, 'rPolicy2', {
+      bucket: 'foo',
+      policyDocument: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+            actions: ['s3:getobject'],
+            effect: Effect.ALLOW,
+            principals: [
+              new OriginAccessIdentity(Stack, 'rOAI2').grantPrincipal
+            ],
+            resources: ['arn:aws:s3:::foo', 'arn:aws:s3:::foo/*']
+          })
+        ]
+      })
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities/typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities_non-compliant.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-s3-bucket-use-cloudfront-origin-access-identities@v1.0 defects=1}
+import { Stack } from 'aws-cdk-lib';
+import {
+  CfnBucket
+} from 'aws-cdk-lib/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Does not use `OriginAccessIdentity`, potentially exposing the bucket publicly.
+    new CfnBucket(Stack, 'rBucket', {
+      websiteConfiguration: {
+        indexDocument: 'index.html',
+        errorDocument: 'error.html'
+      }
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sns-topic-ssl-publish-only/typescript-cdk-sns-topic-ssl-publish-only_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sns-topic-ssl-publish-only/typescript-cdk-sns-topic-ssl-publish-only_compliant.ts
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sns-topic-ssl-publish-only@v1.0 defects=0}
+import {
+    PolicyStatement,
+    PolicyDocument,
+    Effect,
+    StarPrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { CfnTopicPolicy, Topic } from 'aws-cdk-lib/aws-sns';
+import { Stack } from "aws-cdk-lib/core";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Policy uses `Effect.DENY` with `aws:SecureTransport: false` to explicitly block non-SSL connections.
+    new CfnTopicPolicy(Stack, 'rTopicPolicy', {
+      topics: ['foo'],
+      policyDocument: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+        actions: ['sns:Publish'],
+        effect: Effect.DENY,
+        principals: [new StarPrincipal()],
+        conditions: { Bool: { 'aws:SecureTransport': false } },
+        resources: ['foo']
+        })
+      ]
+    }).toJSON()
+  });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sns-topic-ssl-publish-only/typescript-cdk-sns-topic-ssl-publish-only_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sns-topic-ssl-publish-only/typescript-cdk-sns-topic-ssl-publish-only_non-compliant.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sns-topic-ssl-publish-only@v1.0 defects=1}
+import {
+  PolicyStatement,
+  PolicyDocument,
+  Effect,
+  AnyPrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { CfnTopicPolicy, Topic } from 'aws-cdk-lib/aws-sns';
+import { Stack } from "aws-cdk-lib/core";
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+  super(scope, id, props);
+  // Noncompliant: Policy uses `Effect.ALLOW` with `aws:SecureTransport: false` which permits non-SSL connections.
+  new Topic(Stack, 'rTopic', { topicName: 'foo' });
+  new CfnTopicPolicy(Stack, 'rTopicPolicy', {
+    topics: ['foo'],
+    policyDocument: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          actions: ['sns:publish'],
+          effect: Effect.ALLOW,
+          principals: [new AnyPrincipal()],
+          conditions: { Bool: { 'aws:SecureTransport': false } },
+          resources: ['foo']
+        })
+      ]
+    }).toJSON()
+  });
+}
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sqs-queue-ssl-requests-only/typescript-cdk-sqs-queue-ssl-requests-only_compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sqs-queue-ssl-requests-only/typescript-cdk-sqs-queue-ssl-requests-only_compliant.ts
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sqs-queue-ssl-requests-only@v1.0 defects=0}
+import {
+    Effect,
+    PolicyDocument,
+    PolicyStatement,
+    StarPrincipal
+} from 'aws-cdk-lib/aws-iam';
+import { CfnQueuePolicy } from 'aws-cdk-lib/aws-sqs';
+import {  Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);  
+    // Compliant: Policy uses `Effect.DENY` with `aws:SecureTransport: false` to block non-SSL requests.
+    new CfnQueuePolicy(Stack, 'rQueuePolicy', {
+      queues: ['foo'],
+      policyDocument: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+            actions: ['sqs:*'],
+            effect: Effect.DENY,
+            principals: [new StarPrincipal()],
+            conditions: { Bool: { 'aws:SecureTransport': false } },
+            resources: ['foo']
+          })
+        ]
+      }).toJSON()
+    });
+  }
+}
+// {/fact}

--- a/cdk_typescript/src/detectors/typescript-cdk-sqs-queue-ssl-requests-only/typescript-cdk-sqs-queue-ssl-requests-only_non-compliant.ts
+++ b/cdk_typescript/src/detectors/typescript-cdk-sqs-queue-ssl-requests-only/typescript-cdk-sqs-queue-ssl-requests-only_non-compliant.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=typescript-cdk-sqs-queue-ssl-requests-only@v1.0 defects=1}
+import {
+  AnyPrincipal,
+  Effect,
+  PolicyDocument,
+  PolicyStatement
+} from 'aws-cdk-lib/aws-iam';
+import { CfnQueuePolicy, Queue} from 'aws-cdk-lib/aws-sqs';
+import { Stack } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
+
+export class CdkStarterStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);  
+    // Noncompliant: Policy uses `Effect.ALLOW` with `aws:SecureTransport: false` which permits non-SSL requests.
+    new Queue(Stack, 'rQueue', { queueName: 'foo' });
+    new CfnQueuePolicy(Stack, 'rQueuePolicy', {
+      queues: ['foo'],
+      policyDocument: new PolicyDocument({
+        statements: [
+          new PolicyStatement({
+          actions: ['sqs:*'],
+          effect: Effect.ALLOW,
+          principals: [new AnyPrincipal()],
+          conditions: { Bool: { 'aws:SecureTransport': false } },
+          resources: ['foo']
+          })
+        ]
+      }).toJSON()
+    });
+  }
+}
+// {/fact}


### PR DESCRIPTION
Added non compliant and compliant samples for typescript cdk detectors.

Note: All the test cases  have 100 % recall and precision.